### PR TITLE
Implement stuff

### DIFF
--- a/src/__tests__/examples.ts
+++ b/src/__tests__/examples.ts
@@ -1,0 +1,57 @@
+import { print } from '../printer';
+import { read } from '../reader';
+import { evaluate, the_global_environment } from '../evaluator';
+import { getOk } from '../utils';
+
+function expectReadEvalPrint(program: string) {
+  return expect(print(getOk(evaluate(getOk(read(program)), the_global_environment))));
+}
+
+test('plus one', () => {
+  expectReadEvalPrint('(let ([plus1 (lambda (x) (+ x 1))]) (plus1 1))').toMatchInlineSnapshot(
+    `"2"`
+  );
+});
+
+test('thrice thrice', () => {
+  expectReadEvalPrint(`
+    (begin
+      (define (thrice f)
+        (lambda (x) (f (f (f x)))))
+      (((thrice thrice) add1) 0))
+    `).toMatchInlineSnapshot(`"27"`);
+});
+
+test('fibonacci', () => {
+  expectReadEvalPrint(`
+    (begin
+      (define (fib n)
+         (cond [(<= n 1) n]
+               [true (+ (fib (- n 1))
+                        (fib (- n 2)))]))
+      (fib 7))
+    `).toMatchInlineSnapshot(`"13"`);
+});
+
+test("newton's method sqrt", () => {
+  expectReadEvalPrint(`
+    (begin
+      (define tolerance 0.000000000000001)
+      (define (close-enough x y)
+        (< (abs (- x y)) tolerance))
+      (define (fixed-point f first-guess)
+        (define (try-with guess)
+          (define next (f guess))
+          (cond [(close-enough guess next) next]
+                [#t (try-with next)]))
+        (try-with first-guess))
+      (define (average x y) (/ (+ x y) 2))
+      (define (sqrt x)
+        (fixed-point
+          (lambda (y)
+            (average y (/ x y)))
+          1))
+      (list (sqrt 5)                ; square root of 5
+            (* (sqrt 5) (sqrt 5)))) ; square of square root of 5
+    `).toMatchInlineSnapshot(`"(2.23606797749979 5.000000000000001)"`);
+});

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -4,7 +4,7 @@ test('exports', () => {
   expect(Object.keys(index)).toMatchInlineSnapshot(`
     Array [
       "STypes",
-      "satom",
+      "ssymbol",
       "snumber",
       "sboolean",
       "snil",
@@ -14,7 +14,7 @@ test('exports', () => {
       "val",
       "car",
       "cdr",
-      "is_atom",
+      "is_symbol",
       "is_number",
       "is_boolean",
       "is_nil",

--- a/src/__tests__/primitives.ts
+++ b/src/__tests__/primitives.ts
@@ -1,0 +1,515 @@
+import { print } from '../printer';
+import { read } from '../reader';
+import { evaluate, the_global_environment } from '../evaluator';
+import { cases, formatTable, getOk } from '../utils';
+
+function expectOpTable(ops: string[], tests: string[]) {
+  return expect(
+    formatTable(
+      [
+        ...tests.map((test) => [
+          test,
+          ...ops.map((op) =>
+            cases(
+              evaluate(getOk(read(`(let ([op ${op}]) ${test})`)), the_global_environment),
+              print,
+              (e) => (e === undefined ? 'ERR' : JSON.stringify(e))
+            )
+          ),
+        ]),
+      ],
+      { headers: ['test', ...ops], sep: ' | ', prefix: '\n' }
+    )
+  );
+}
+
+// Exporting these to suppress unused locals warnings
+
+export const zeroArgTests = [
+  // 0 args
+  '(op)',
+];
+
+export const oneArgTests = [
+  // 1 arg
+  '(op 0)',
+  '(op 1)',
+  '(op 2)',
+  '(op 0.1)',
+  '(op 2.4)',
+  '(op 2.5)',
+  '(op 2.6)',
+  '(op -2.4)',
+  '(op -2.5)',
+  '(op -2.6)',
+  '(op -1)',
+  '(op -2)',
+  '(op +inf.0)',
+  '(op -inf.0)',
+  '(op +nan.0)',
+];
+
+export const twoNumArgTests = [
+  // 2 args
+  '(op 0 0)',
+  '(op 1 0)',
+  '(op 0 1)',
+  '(op 1 1)',
+  '(op 3 5)',
+  '(op 5 3)',
+
+  '(op 0 +inf.0)',
+  '(op 1 +inf.0)',
+  '(op 2 +inf.0)',
+  '(op +inf.0 0)',
+  '(op +inf.0 1)',
+  '(op +inf.0 2)',
+  '(op +inf.0 +inf.0)',
+
+  '(op 0.1 0)',
+  '(op 0 0.1)',
+  '(op 0.1 0.1)',
+  '(op 0.3 0.5)',
+  '(op 0.5 0.3)',
+
+  '(op 3 5)',
+  '(op -3 5)',
+  '(op 3 -5)',
+  '(op -3 -5)',
+];
+
+export const mixedTypesArgTests = [
+  '(op 0)',
+
+  '(op +inf.0)',
+  '(op -inf.0)',
+  '(op +nan.0)',
+
+  '(op #f)',
+  '(op #t)',
+
+  "(op 'a)",
+
+  '(op 0 0)',
+  '(op 1 0)',
+  '(op 3 5)',
+
+  '(op #f #f)',
+  '(op #t #f)',
+  '(op #f #t)',
+  '(op #t #t)',
+
+  "(op 'a 'a)",
+  "(op 'a 'b)",
+
+  '(op #f 0)',
+  "(op 'a 0)",
+  "(op 0 'a)",
+  '(op 1 #t)',
+
+  '(op 1 1 1 1)',
+  '(op 1 2 3 4)',
+
+  '(op #f #f #f)',
+  '(op #f #f #f #f)',
+  '(op #t #t #t)',
+  '(op #t #f #t)',
+
+  "(op 'a 'a 'a)",
+  "(op 'a 'b 'b)",
+  "(op 'a 'b 'c)",
+
+  "(op 1 2 #t 1 'a)",
+];
+
+export const manyNumArgTests = [
+  // many args
+  '(op 1 1 1 1 1)',
+  '(op 2 2 2 1 1)',
+  '(op 1 1 1 2 2)',
+  '(op 1 4 3 5 2)',
+  '(op 1 2 3 4 4)',
+  '(op 4 4 3 2 1)',
+  '(op 11 13 17)',
+  '(op 1 2 3 4 5)',
+  '(op 5 4 3 2 1)',
+];
+
+export const manySymbolArgTests = [
+  "(op 'a 'a 'a)",
+  "(op 'a 'a 'b)",
+  "(op 'a 'b 'a)",
+  "(op 'a 'b 'b)",
+  "(op 'a 'b 'c)",
+
+  "(op 'a 'a 'a 'a 'a 'a 'a 'a)",
+  "(op 'a 'a 'a 'a 'a 'a 'b 'a)",
+  "(op 'a 'b 'c 'd 'e 'f 'g 'h)",
+];
+
+export const malformedArgTests = [
+  // malformed function call
+  '(op 1 . 2)',
+  '(op . 1)',
+
+  // unbound vars
+  '(op a)',
+  '(op a a)',
+
+  // error when evaluating arguments
+  '(op ())',
+];
+
+export const oneListArgTests = [
+  "(op '())",
+  "(op '(1))",
+  "(op '(1 2))",
+  "(op '(1 2 3 4 5))",
+  "(op '(1 #t))",
+];
+
+test('type predicates', () => {
+  expectOpTable(
+    ['symbol?', 'number?', 'boolean?', 'null?', 'cons?', 'data?', 'nan?', 'infinite?'],
+    []
+  ).toMatchInlineSnapshot(`""`);
+});
+
+test('unary arithmetic ops', () => {
+  expectOpTable(
+    [
+      'zero?',
+      'positive?',
+      'negative?',
+      'round',
+      'floor',
+      'ceiling',
+      'truncate',
+      'sgn',
+      'abs',
+      'add1',
+      'sub1',
+      'exp',
+      'log',
+    ],
+    []
+  ).toMatchInlineSnapshot(`""`);
+});
+
+test('2 arg log', () => {
+  expectOpTable(['log'], []).toMatchInlineSnapshot(`""`);
+});
+
+test('exactly binary numeric ops', () => {
+  expectOpTable(['quotient', 'remainder', 'modulo', 'expt', 'log'], [...mixedTypesArgTests])
+    .toMatchInlineSnapshot(`
+    "
+    test             | quotient | remainder | modulo | expt | log
+    ----------------------------------------------------------------------------
+    (op 0)           | ERR      | ERR       | ERR    | ERR  | -inf.0
+    (op +inf.0)      | ERR      | ERR       | ERR    | ERR  | +inf.0
+    (op -inf.0)      | ERR      | ERR       | ERR    | ERR  | +nan.0
+    (op +nan.0)      | ERR      | ERR       | ERR    | ERR  | +nan.0
+    (op #f)          | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #t)          | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 'a)          | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 0 0)         | ERR      | ERR       | ERR    | 1    | +nan.0
+    (op 1 0)         | ERR      | ERR       | ERR    | 1    | 0
+    (op 3 5)         | 0        | 3         | 3      | 243  | 0.6826061944859853
+    (op #f #f)       | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #t #f)       | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #f #t)       | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #t #t)       | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 'a 'a)       | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 'a 'b)       | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #f 0)        | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 'a 0)        | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 0 'a)        | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 1 #t)        | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 1 1 1 1)     | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 1 2 3 4)     | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #f #f #f)    | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #f #f #f #f) | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #t #t #t)    | ERR      | ERR       | ERR    | ERR  | ERR
+    (op #t #f #t)    | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 'a 'a 'a)    | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 'a 'b 'b)    | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 'a 'b 'c)    | ERR      | ERR       | ERR    | ERR  | ERR
+    (op 1 2 #t 1 'a) | ERR      | ERR       | ERR    | ERR  | ERR
+    "
+  `);
+});
+
+test('variable arity arithmetic ops', () => {
+  expectOpTable(
+    ['+', '-', '*', '/', 'max', 'min'],
+    [
+      ...zeroArgTests,
+      ...oneArgTests,
+      ...twoNumArgTests,
+      ...manyNumArgTests,
+      ...mixedTypesArgTests,
+      ...malformedArgTests,
+
+      '(op (op 1 2) 3)',
+      '(op 1 (op 2 3))',
+    ]
+  ).toMatchInlineSnapshot(`
+    "
+    test               | +      | -      | *                    | /                    | max    | min
+    ----------------------------------------------------------------------------------------------------
+    (op)               | 0      | ERR    | 1                    | ERR                  | -inf.0 | +inf.0
+    (op 0)             | 0      | 0      | 0                    | ERR                  | 0      | 0
+    (op 1)             | 1      | -1     | 1                    | 1                    | 1      | 1
+    (op 2)             | 2      | -2     | 2                    | 0.5                  | 2      | 2
+    (op 0.1)           | 0.1    | -0.1   | 0.1                  | 10                   | 0.1    | 0.1
+    (op 2.4)           | 2.4    | -2.4   | 2.4                  | 0.4166666666666667   | 2.4    | 2.4
+    (op 2.5)           | 2.5    | -2.5   | 2.5                  | 0.4                  | 2.5    | 2.5
+    (op 2.6)           | 2.6    | -2.6   | 2.6                  | 0.3846153846153846   | 2.6    | 2.6
+    (op -2.4)          | -2.4   | 2.4    | -2.4                 | -0.4166666666666667  | -2.4   | -2.4
+    (op -2.5)          | -2.5   | 2.5    | -2.5                 | -0.4                 | -2.5   | -2.5
+    (op -2.6)          | -2.6   | 2.6    | -2.6                 | -0.3846153846153846  | -2.6   | -2.6
+    (op -1)            | -1     | 1      | -1                   | -1                   | -1     | -1
+    (op -2)            | -2     | 2      | -2                   | -0.5                 | -2     | -2
+    (op +inf.0)        | +inf.0 | -inf.0 | +inf.0               | 0                    | +inf.0 | +inf.0
+    (op -inf.0)        | -inf.0 | +inf.0 | -inf.0               | 0                    | -inf.0 | -inf.0
+    (op +nan.0)        | +nan.0 | +nan.0 | +nan.0               | +nan.0               | +nan.0 | +nan.0
+    (op 0 0)           | 0      | 0      | 0                    | ERR                  | 0      | 0
+    (op 1 0)           | 1      | 1      | 0                    | ERR                  | 1      | 0
+    (op 0 1)           | 1      | -1     | 0                    | 0                    | 1      | 0
+    (op 1 1)           | 2      | 0      | 1                    | 1                    | 1      | 1
+    (op 3 5)           | 8      | -2     | 15                   | 0.6                  | 5      | 3
+    (op 5 3)           | 8      | 2      | 15                   | 1.6666666666666667   | 5      | 3
+    (op 0 +inf.0)      | +inf.0 | -inf.0 | +nan.0               | 0                    | +inf.0 | 0
+    (op 1 +inf.0)      | +inf.0 | -inf.0 | +inf.0               | 0                    | +inf.0 | 1
+    (op 2 +inf.0)      | +inf.0 | -inf.0 | +inf.0               | 0                    | +inf.0 | 2
+    (op +inf.0 0)      | +inf.0 | +inf.0 | +nan.0               | ERR                  | +inf.0 | 0
+    (op +inf.0 1)      | +inf.0 | +inf.0 | +inf.0               | +inf.0               | +inf.0 | 1
+    (op +inf.0 2)      | +inf.0 | +inf.0 | +inf.0               | +inf.0               | +inf.0 | 2
+    (op +inf.0 +inf.0) | +inf.0 | +nan.0 | +inf.0               | +nan.0               | +inf.0 | +inf.0
+    (op 0.1 0)         | 0.1    | 0.1    | 0                    | ERR                  | 0.1    | 0
+    (op 0 0.1)         | 0.1    | -0.1   | 0                    | 0                    | 0.1    | 0
+    (op 0.1 0.1)       | 0.2    | 0      | 0.010000000000000002 | 1                    | 0.1    | 0.1
+    (op 0.3 0.5)       | 0.8    | -0.2   | 0.15                 | 0.6                  | 0.5    | 0.3
+    (op 0.5 0.3)       | 0.8    | 0.2    | 0.15                 | 1.6666666666666667   | 0.5    | 0.3
+    (op 3 5)           | 8      | -2     | 15                   | 0.6                  | 5      | 3
+    (op -3 5)          | 2      | -8     | -15                  | -0.6                 | 5      | -3
+    (op 3 -5)          | -2     | 8      | -15                  | -0.6                 | 3      | -5
+    (op -3 -5)         | -8     | 2      | 15                   | 0.6                  | -3     | -5
+    (op 1 1 1 1 1)     | 5      | -3     | 1                    | 1                    | 1      | 1
+    (op 2 2 2 1 1)     | 8      | -4     | 8                    | 0.5                  | 2      | 1
+    (op 1 1 1 2 2)     | 7      | -5     | 4                    | 0.25                 | 2      | 1
+    (op 1 4 3 5 2)     | 15     | -13    | 120                  | 0.008333333333333333 | 5      | 1
+    (op 1 2 3 4 4)     | 14     | -12    | 96                   | 0.010416666666666666 | 4      | 1
+    (op 4 4 3 2 1)     | 14     | -6     | 96                   | 0.16666666666666666  | 4      | 1
+    (op 11 13 17)      | 41     | -19    | 2431                 | 0.049773755656108594 | 17     | 11
+    (op 1 2 3 4 5)     | 15     | -13    | 120                  | 0.008333333333333333 | 5      | 1
+    (op 5 4 3 2 1)     | 15     | -5     | 120                  | 0.20833333333333334  | 5      | 1
+    (op 0)             | 0      | 0      | 0                    | ERR                  | 0      | 0
+    (op +inf.0)        | +inf.0 | -inf.0 | +inf.0               | 0                    | +inf.0 | +inf.0
+    (op -inf.0)        | -inf.0 | +inf.0 | -inf.0               | 0                    | -inf.0 | -inf.0
+    (op +nan.0)        | +nan.0 | +nan.0 | +nan.0               | +nan.0               | +nan.0 | +nan.0
+    (op #f)            | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #t)            | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 'a)            | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 0 0)           | 0      | 0      | 0                    | ERR                  | 0      | 0
+    (op 1 0)           | 1      | 1      | 0                    | ERR                  | 1      | 0
+    (op 3 5)           | 8      | -2     | 15                   | 0.6                  | 5      | 3
+    (op #f #f)         | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #t #f)         | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #f #t)         | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #t #t)         | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 'a 'a)         | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 'a 'b)         | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #f 0)          | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 'a 0)          | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 0 'a)          | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 1 #t)          | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 1 1 1 1)       | 4      | -2     | 1                    | 1                    | 1      | 1
+    (op 1 2 3 4)       | 10     | -8     | 24                   | 0.041666666666666664 | 4      | 1
+    (op #f #f #f)      | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #f #f #f #f)   | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #t #t #t)      | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op #t #f #t)      | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 'a 'a 'a)      | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 'a 'b 'b)      | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 'a 'b 'c)      | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 1 2 #t 1 'a)   | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op 1 . 2)         | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op . 1)           | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op a)             | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op a a)           | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op ())            | ERR    | ERR    | ERR                  | ERR                  | ERR    | ERR
+    (op (op 1 2) 3)    | 6      | -4     | 6                    | 0.16666666666666666  | 3      | 1
+    (op 1 (op 2 3))    | 6      | 2      | 6                    | 1.5                  | 3      | 1
+    "
+  `);
+});
+
+test('numeric comparsion ops', () => {
+  expectOpTable(
+    ['=', '<', '>', '<=', '>='],
+    [...zeroArgTests, '(op 0)', ...twoNumArgTests, ...manyNumArgTests, ...mixedTypesArgTests]
+  ).toMatchInlineSnapshot(`
+    "
+    test               | =   | <   | >   | <=  | >=
+    ------------------------------------------------
+    (op)               | ERR | ERR | ERR | ERR | ERR
+    (op 0)             | #t  | #t  | #t  | #t  | #t
+    (op 0 0)           | #t  | #f  | #f  | #t  | #t
+    (op 1 0)           | #f  | #f  | #t  | #f  | #t
+    (op 0 1)           | #f  | #t  | #f  | #t  | #f
+    (op 1 1)           | #t  | #f  | #f  | #t  | #t
+    (op 3 5)           | #f  | #t  | #f  | #t  | #f
+    (op 5 3)           | #f  | #f  | #t  | #f  | #t
+    (op 0 +inf.0)      | #f  | #t  | #f  | #t  | #f
+    (op 1 +inf.0)      | #f  | #t  | #f  | #t  | #f
+    (op 2 +inf.0)      | #f  | #t  | #f  | #t  | #f
+    (op +inf.0 0)      | #f  | #f  | #t  | #f  | #t
+    (op +inf.0 1)      | #f  | #f  | #t  | #f  | #t
+    (op +inf.0 2)      | #f  | #f  | #t  | #f  | #t
+    (op +inf.0 +inf.0) | #t  | #f  | #f  | #t  | #t
+    (op 0.1 0)         | #f  | #f  | #t  | #f  | #t
+    (op 0 0.1)         | #f  | #t  | #f  | #t  | #f
+    (op 0.1 0.1)       | #t  | #f  | #f  | #t  | #t
+    (op 0.3 0.5)       | #f  | #t  | #f  | #t  | #f
+    (op 0.5 0.3)       | #f  | #f  | #t  | #f  | #t
+    (op 3 5)           | #f  | #t  | #f  | #t  | #f
+    (op -3 5)          | #f  | #t  | #f  | #t  | #f
+    (op 3 -5)          | #f  | #f  | #t  | #f  | #t
+    (op -3 -5)         | #f  | #f  | #t  | #f  | #t
+    (op 1 1 1 1 1)     | #t  | #f  | #f  | #t  | #t
+    (op 2 2 2 1 1)     | #f  | #f  | #f  | #f  | #t
+    (op 1 1 1 2 2)     | #f  | #f  | #f  | #t  | #f
+    (op 1 4 3 5 2)     | #f  | #f  | #f  | #f  | #f
+    (op 1 2 3 4 4)     | #f  | #f  | #f  | #t  | #f
+    (op 4 4 3 2 1)     | #f  | #f  | #f  | #f  | #t
+    (op 11 13 17)      | #f  | #t  | #f  | #t  | #f
+    (op 1 2 3 4 5)     | #f  | #t  | #f  | #t  | #f
+    (op 5 4 3 2 1)     | #f  | #f  | #t  | #f  | #t
+    (op 0)             | #t  | #t  | #t  | #t  | #t
+    (op +inf.0)        | #t  | #t  | #t  | #t  | #t
+    (op -inf.0)        | #t  | #t  | #t  | #t  | #t
+    (op +nan.0)        | #t  | #t  | #t  | #t  | #t
+    (op #f)            | ERR | ERR | ERR | ERR | ERR
+    (op #t)            | ERR | ERR | ERR | ERR | ERR
+    (op 'a)            | ERR | ERR | ERR | ERR | ERR
+    (op 0 0)           | #t  | #f  | #f  | #t  | #t
+    (op 1 0)           | #f  | #f  | #t  | #f  | #t
+    (op 3 5)           | #f  | #t  | #f  | #t  | #f
+    (op #f #f)         | ERR | ERR | ERR | ERR | ERR
+    (op #t #f)         | ERR | ERR | ERR | ERR | ERR
+    (op #f #t)         | ERR | ERR | ERR | ERR | ERR
+    (op #t #t)         | ERR | ERR | ERR | ERR | ERR
+    (op 'a 'a)         | ERR | ERR | ERR | ERR | ERR
+    (op 'a 'b)         | ERR | ERR | ERR | ERR | ERR
+    (op #f 0)          | ERR | ERR | ERR | ERR | ERR
+    (op 'a 0)          | ERR | ERR | ERR | ERR | ERR
+    (op 0 'a)          | ERR | ERR | ERR | ERR | ERR
+    (op 1 #t)          | ERR | ERR | ERR | ERR | ERR
+    (op 1 1 1 1)       | #t  | #f  | #f  | #t  | #t
+    (op 1 2 3 4)       | #f  | #t  | #f  | #t  | #f
+    (op #f #f #f)      | ERR | ERR | ERR | ERR | ERR
+    (op #f #f #f #f)   | ERR | ERR | ERR | ERR | ERR
+    (op #t #t #t)      | ERR | ERR | ERR | ERR | ERR
+    (op #t #f #t)      | ERR | ERR | ERR | ERR | ERR
+    (op 'a 'a 'a)      | ERR | ERR | ERR | ERR | ERR
+    (op 'a 'b 'b)      | ERR | ERR | ERR | ERR | ERR
+    (op 'a 'b 'c)      | ERR | ERR | ERR | ERR | ERR
+    (op 1 2 #t 1 'a)   | ERR | ERR | ERR | ERR | ERR
+    "
+  `);
+});
+
+test('trigonometric ops', () => {
+  expectOpTable(
+    ['sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'sinh', 'cosh', 'tanh'],
+    [...mixedTypesArgTests]
+  ).toMatchInlineSnapshot(`
+    "
+    test             | sin    | cos    | tan    | asin   | acos               | atan                | sinh   | cosh   | tanh
+    --------------------------------------------------------------------------------------------------------------------------
+    (op 0)           | 0      | 1      | 0      | 0      | 1.5707963267948966 | 0                   | 0      | 1      | 0
+    (op +inf.0)      | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0             | 1.5707963267948966  | +inf.0 | +inf.0 | 1
+    (op -inf.0)      | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0             | -1.5707963267948966 | -inf.0 | +inf.0 | -1
+    (op +nan.0)      | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0             | +nan.0              | +nan.0 | +nan.0 | +nan.0
+    (op #f)          | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #t)          | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 'a)          | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 0 0)         | ERR    | ERR    | ERR    | ERR    | ERR                | 0                   | ERR    | ERR    | ERR
+    (op 1 0)         | ERR    | ERR    | ERR    | ERR    | ERR                | 1.5707963267948966  | ERR    | ERR    | ERR
+    (op 3 5)         | ERR    | ERR    | ERR    | ERR    | ERR                | 0.5404195002705842  | ERR    | ERR    | ERR
+    (op #f #f)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #t #f)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #f #t)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #t #t)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 'a 'a)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 'a 'b)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #f 0)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 'a 0)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 0 'a)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 1 #t)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 1 1 1 1)     | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 1 2 3 4)     | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #f #f #f)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #f #f #f #f) | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #t #t #t)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op #t #f #t)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 'a 'a 'a)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 'a 'b 'b)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 'a 'b 'c)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    (op 1 2 #t 1 'a) | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    "
+  `);
+});
+
+test('2 arg atan', () => {
+  expectOpTable(['atan'], []).toMatchInlineSnapshot(`""`);
+});
+
+test('boolean ops', () => {
+  expectOpTable(
+    ['and', 'or', 'nand', 'nor', 'xor', 'implies', 'not', 'false?'],
+    [...mixedTypesArgTests]
+  ).toMatchInlineSnapshot(`
+    "
+    test             | and | or  | nand | nor | xor | implies | not | false?
+    ------------------------------------------------------------------------
+    (op 0)           | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op +inf.0)      | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op -inf.0)      | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op +nan.0)      | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op #f)          | #f  | #f  | #t   | #t  | #f  | ERR     | #t  | #t
+    (op #t)          | #t  | #t  | #f   | #f  | #t  | ERR     | #f  | #f
+    (op 'a)          | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 0 0)         | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 1 0)         | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 3 5)         | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op #f #f)       | #f  | #f  | #t   | #t  | #f  | #t      | ERR | ERR
+    (op #t #f)       | #f  | #t  | #t   | #f  | #t  | #f      | ERR | ERR
+    (op #f #t)       | #f  | #t  | #t   | #f  | #t  | #t      | ERR | ERR
+    (op #t #t)       | #t  | #t  | #f   | #f  | #f  | #t      | ERR | ERR
+    (op 'a 'a)       | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 'a 'b)       | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op #f 0)        | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 'a 0)        | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 0 'a)        | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 1 #t)        | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 1 1 1 1)     | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 1 2 3 4)     | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op #f #f #f)    | #f  | #f  | #t   | #t  | #f  | ERR     | ERR | ERR
+    (op #f #f #f #f) | #f  | #f  | #t   | #t  | #f  | ERR     | ERR | ERR
+    (op #t #t #t)    | #t  | #t  | #f   | #f  | #t  | ERR     | ERR | ERR
+    (op #t #f #t)    | #f  | #t  | #t   | #f  | #f  | ERR     | ERR | ERR
+    (op 'a 'a 'a)    | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 'a 'b 'b)    | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 'a 'b 'c)    | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    (op 1 2 #t 1 'a) | ERR | ERR | ERR  | ERR | ERR | ERR     | ERR | ERR
+    "
+  `);
+});
+
+// these prolly need manual testing
+// const listOps = ['cons', 'list', 'list*', 'car', 'cdr', 'first', 'rest', 'last', 'last-pair'];
+// const valueEqualityOps = ['eq?', 'symbol=?', 'number=?', 'boolean=?'];
+// const listEqualityOps = ['equal?'];

--- a/src/__tests__/primitives.ts
+++ b/src/__tests__/primitives.ts
@@ -422,49 +422,258 @@ test('numeric comparsion ops', () => {
 });
 
 test('trigonometric ops', () => {
+  // ,
   expectOpTable(
-    ['sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'sinh', 'cosh', 'tanh'],
-    [...mixedTypesArgTests]
+    ['sin', 'cos', 'tan'],
+    [
+      ...zeroArgTests,
+      '(op (* (/ -2 1) pi))',
+      '(op (* (/ -1 1) pi))',
+      '(op (* (/ -1 2) pi))',
+      '(op (* (/ -1 3) pi))',
+      '(op (* (/ -1 4) pi))',
+      '(op (* (/ -1 6) pi))',
+      '(op 0)',
+      '(op (* (/ 1 6) pi))',
+      '(op (* (/ 1 4) pi))',
+      '(op (* (/ 1 3) pi))',
+      '(op (* (/ 1 2) pi))',
+      '(op (* (/ 1 1) pi))',
+      '(op (* (/ 2 1) pi))',
+      ...mixedTypesArgTests,
+    ]
   ).toMatchInlineSnapshot(`
     "
-    test             | sin    | cos    | tan    | asin   | acos               | atan                | sinh   | cosh   | tanh
-    --------------------------------------------------------------------------------------------------------------------------
-    (op 0)           | 0      | 1      | 0      | 0      | 1.5707963267948966 | 0                   | 0      | 1      | 0
-    (op +inf.0)      | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0             | 1.5707963267948966  | +inf.0 | +inf.0 | 1
-    (op -inf.0)      | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0             | -1.5707963267948966 | -inf.0 | +inf.0 | -1
-    (op +nan.0)      | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0             | +nan.0              | +nan.0 | +nan.0 | +nan.0
-    (op #f)          | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #t)          | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 'a)          | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 0 0)         | ERR    | ERR    | ERR    | ERR    | ERR                | 0                   | ERR    | ERR    | ERR
-    (op 1 0)         | ERR    | ERR    | ERR    | ERR    | ERR                | 1.5707963267948966  | ERR    | ERR    | ERR
-    (op 3 5)         | ERR    | ERR    | ERR    | ERR    | ERR                | 0.5404195002705842  | ERR    | ERR    | ERR
-    (op #f #f)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #t #f)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #f #t)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #t #t)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 'a 'a)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 'a 'b)       | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #f 0)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 'a 0)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 0 'a)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 1 #t)        | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 1 1 1 1)     | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 1 2 3 4)     | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #f #f #f)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #f #f #f #f) | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #t #t #t)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op #t #f #t)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 'a 'a 'a)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 'a 'b 'b)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 'a 'b 'c)    | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
-    (op 1 2 #t 1 'a) | ERR    | ERR    | ERR    | ERR    | ERR                | ERR                 | ERR    | ERR    | ERR
+    test                 | sin                     | cos                   | tan
+    ------------------------------------------------------------------------------------------------
+    (op)                 | ERR                     | ERR                   | ERR
+    (op (* (/ -2 1) pi)) | 2.4492935982947064e-16  | 1                     | 2.4492935982947064e-16
+    (op (* (/ -1 1) pi)) | -1.2246467991473532e-16 | -1                    | 1.2246467991473532e-16
+    (op (* (/ -1 2) pi)) | -1                      | 6.123233995736766e-17 | -16331239353195370
+    (op (* (/ -1 3) pi)) | -0.8660254037844386     | 0.5000000000000001    | -1.7320508075688767
+    (op (* (/ -1 4) pi)) | -0.7071067811865475     | 0.7071067811865476    | -0.9999999999999999
+    (op (* (/ -1 6) pi)) | -0.49999999999999994    | 0.8660254037844387    | -0.5773502691896257
+    (op 0)               | 0                       | 1                     | 0
+    (op (* (/ 1 6) pi))  | 0.49999999999999994     | 0.8660254037844387    | 0.5773502691896257
+    (op (* (/ 1 4) pi))  | 0.7071067811865475      | 0.7071067811865476    | 0.9999999999999999
+    (op (* (/ 1 3) pi))  | 0.8660254037844386      | 0.5000000000000001    | 1.7320508075688767
+    (op (* (/ 1 2) pi))  | 1                       | 6.123233995736766e-17 | 16331239353195370
+    (op (* (/ 1 1) pi))  | 1.2246467991473532e-16  | -1                    | -1.2246467991473532e-16
+    (op (* (/ 2 1) pi))  | -2.4492935982947064e-16 | 1                     | -2.4492935982947064e-16
+    (op 0)               | 0                       | 1                     | 0
+    (op +inf.0)          | +nan.0                  | +nan.0                | +nan.0
+    (op -inf.0)          | +nan.0                  | +nan.0                | +nan.0
+    (op +nan.0)          | +nan.0                  | +nan.0                | +nan.0
+    (op #f)              | ERR                     | ERR                   | ERR
+    (op #t)              | ERR                     | ERR                   | ERR
+    (op 'a)              | ERR                     | ERR                   | ERR
+    (op 0 0)             | ERR                     | ERR                   | ERR
+    (op 1 0)             | ERR                     | ERR                   | ERR
+    (op 3 5)             | ERR                     | ERR                   | ERR
+    (op #f #f)           | ERR                     | ERR                   | ERR
+    (op #t #f)           | ERR                     | ERR                   | ERR
+    (op #f #t)           | ERR                     | ERR                   | ERR
+    (op #t #t)           | ERR                     | ERR                   | ERR
+    (op 'a 'a)           | ERR                     | ERR                   | ERR
+    (op 'a 'b)           | ERR                     | ERR                   | ERR
+    (op #f 0)            | ERR                     | ERR                   | ERR
+    (op 'a 0)            | ERR                     | ERR                   | ERR
+    (op 0 'a)            | ERR                     | ERR                   | ERR
+    (op 1 #t)            | ERR                     | ERR                   | ERR
+    (op 1 1 1 1)         | ERR                     | ERR                   | ERR
+    (op 1 2 3 4)         | ERR                     | ERR                   | ERR
+    (op #f #f #f)        | ERR                     | ERR                   | ERR
+    (op #f #f #f #f)     | ERR                     | ERR                   | ERR
+    (op #t #t #t)        | ERR                     | ERR                   | ERR
+    (op #t #f #t)        | ERR                     | ERR                   | ERR
+    (op 'a 'a 'a)        | ERR                     | ERR                   | ERR
+    (op 'a 'b 'b)        | ERR                     | ERR                   | ERR
+    (op 'a 'b 'c)        | ERR                     | ERR                   | ERR
+    (op 1 2 #t 1 'a)     | ERR                     | ERR                   | ERR
+    "
+  `);
+
+  expectOpTable(
+    ['asin', 'acos', 'atan'],
+    [
+      ...zeroArgTests,
+      '(/ (op -2) pi)',
+      '(/ (op -1) pi)',
+      '(/ (op -0.8660254037844387) pi)',
+      '(/ (op -0.7071067811865476) pi)',
+      '(/ (op -0.5000000000000001) pi)',
+      '(/ (op 0) pi)',
+      '(/ (op 0.5000000000000001) pi)',
+      '(/ (op 0.7071067811865476) pi)',
+      '(/ (op 1) pi)',
+      '(/ (op 2) pi)',
+      ...mixedTypesArgTests,
+    ]
+  ).toMatchInlineSnapshot(`
+    "
+    test                            | asin                 | acos               | atan
+    --------------------------------------------------------------------------------------------------
+    (op)                            | ERR                  | ERR                | ERR
+    (/ (op -2) pi)                  | +nan.0               | +nan.0             | -0.35241638234956674
+    (/ (op -1) pi)                  | -0.5                 | 1                  | -0.25
+    (/ (op -0.8660254037844387) pi) | -0.33333333333333337 | 0.8333333333333334 | -0.22718552582850507
+    (/ (op -0.7071067811865476) pi) | -0.25000000000000006 | 0.75               | -0.19591327601530364
+    (/ (op -0.5000000000000001) pi) | -0.1666666666666667  | 0.6666666666666667 | -0.14758361765043332
+    (/ (op 0) pi)                   | 0                    | 0.5                | 0
+    (/ (op 0.5000000000000001) pi)  | 0.1666666666666667   | 0.3333333333333333 | 0.14758361765043332
+    (/ (op 0.7071067811865476) pi)  | 0.25000000000000006  | 0.25               | 0.19591327601530364
+    (/ (op 1) pi)                   | 0.5                  | 0                  | 0.25
+    (/ (op 2) pi)                   | +nan.0               | +nan.0             | 0.35241638234956674
+    (op 0)                          | 0                    | 1.5707963267948966 | 0
+    (op +inf.0)                     | +nan.0               | +nan.0             | 1.5707963267948966
+    (op -inf.0)                     | +nan.0               | +nan.0             | -1.5707963267948966
+    (op +nan.0)                     | +nan.0               | +nan.0             | +nan.0
+    (op #f)                         | ERR                  | ERR                | ERR
+    (op #t)                         | ERR                  | ERR                | ERR
+    (op 'a)                         | ERR                  | ERR                | ERR
+    (op 0 0)                        | ERR                  | ERR                | 0
+    (op 1 0)                        | ERR                  | ERR                | 1.5707963267948966
+    (op 3 5)                        | ERR                  | ERR                | 0.5404195002705842
+    (op #f #f)                      | ERR                  | ERR                | ERR
+    (op #t #f)                      | ERR                  | ERR                | ERR
+    (op #f #t)                      | ERR                  | ERR                | ERR
+    (op #t #t)                      | ERR                  | ERR                | ERR
+    (op 'a 'a)                      | ERR                  | ERR                | ERR
+    (op 'a 'b)                      | ERR                  | ERR                | ERR
+    (op #f 0)                       | ERR                  | ERR                | ERR
+    (op 'a 0)                       | ERR                  | ERR                | ERR
+    (op 0 'a)                       | ERR                  | ERR                | ERR
+    (op 1 #t)                       | ERR                  | ERR                | ERR
+    (op 1 1 1 1)                    | ERR                  | ERR                | ERR
+    (op 1 2 3 4)                    | ERR                  | ERR                | ERR
+    (op #f #f #f)                   | ERR                  | ERR                | ERR
+    (op #f #f #f #f)                | ERR                  | ERR                | ERR
+    (op #t #t #t)                   | ERR                  | ERR                | ERR
+    (op #t #f #t)                   | ERR                  | ERR                | ERR
+    (op 'a 'a 'a)                   | ERR                  | ERR                | ERR
+    (op 'a 'b 'b)                   | ERR                  | ERR                | ERR
+    (op 'a 'b 'c)                   | ERR                  | ERR                | ERR
+    (op 1 2 #t 1 'a)                | ERR                  | ERR                | ERR
+    "
+  `);
+
+  expectOpTable(
+    ['sinh', 'cosh', 'tanh'],
+    [
+      ...zeroArgTests,
+      '(op 0)',
+      '(op 1)',
+      '(* 0.5 (- (exp 1) (exp -1)))',
+      '(* 0.5 (+ (exp 1) (exp -1)))',
+      '(/ (- (exp 1) (exp -1)) (+ (exp 1) (exp -1)))',
+      ...mixedTypesArgTests,
+    ]
+  ).toMatchInlineSnapshot(`
+    "
+    test                                          | sinh               | cosh               | tanh
+    ------------------------------------------------------------------------------------------------------------
+    (op)                                          | ERR                | ERR                | ERR
+    (op 0)                                        | 0                  | 1                  | 0
+    (op 1)                                        | 1.1752011936438014 | 1.5430806348152437 | 0.7615941559557649
+    (* 0.5 (- (exp 1) (exp -1)))                  | 1.1752011936438014 | 1.1752011936438014 | 1.1752011936438014
+    (* 0.5 (+ (exp 1) (exp -1)))                  | 1.5430806348152437 | 1.5430806348152437 | 1.5430806348152437
+    (/ (- (exp 1) (exp -1)) (+ (exp 1) (exp -1))) | 0.7615941559557649 | 0.7615941559557649 | 0.7615941559557649
+    (op 0)                                        | 0                  | 1                  | 0
+    (op +inf.0)                                   | +inf.0             | +inf.0             | 1
+    (op -inf.0)                                   | -inf.0             | +inf.0             | -1
+    (op +nan.0)                                   | +nan.0             | +nan.0             | +nan.0
+    (op #f)                                       | ERR                | ERR                | ERR
+    (op #t)                                       | ERR                | ERR                | ERR
+    (op 'a)                                       | ERR                | ERR                | ERR
+    (op 0 0)                                      | ERR                | ERR                | ERR
+    (op 1 0)                                      | ERR                | ERR                | ERR
+    (op 3 5)                                      | ERR                | ERR                | ERR
+    (op #f #f)                                    | ERR                | ERR                | ERR
+    (op #t #f)                                    | ERR                | ERR                | ERR
+    (op #f #t)                                    | ERR                | ERR                | ERR
+    (op #t #t)                                    | ERR                | ERR                | ERR
+    (op 'a 'a)                                    | ERR                | ERR                | ERR
+    (op 'a 'b)                                    | ERR                | ERR                | ERR
+    (op #f 0)                                     | ERR                | ERR                | ERR
+    (op 'a 0)                                     | ERR                | ERR                | ERR
+    (op 0 'a)                                     | ERR                | ERR                | ERR
+    (op 1 #t)                                     | ERR                | ERR                | ERR
+    (op 1 1 1 1)                                  | ERR                | ERR                | ERR
+    (op 1 2 3 4)                                  | ERR                | ERR                | ERR
+    (op #f #f #f)                                 | ERR                | ERR                | ERR
+    (op #f #f #f #f)                              | ERR                | ERR                | ERR
+    (op #t #t #t)                                 | ERR                | ERR                | ERR
+    (op #t #f #t)                                 | ERR                | ERR                | ERR
+    (op 'a 'a 'a)                                 | ERR                | ERR                | ERR
+    (op 'a 'b 'b)                                 | ERR                | ERR                | ERR
+    (op 'a 'b 'c)                                 | ERR                | ERR                | ERR
+    (op 1 2 #t 1 'a)                              | ERR                | ERR                | ERR
     "
   `);
 });
 
 test('2 arg atan', () => {
-  expectOpTable(['atan'], []).toMatchInlineSnapshot(`""`);
+  expectOpTable(
+    ['atan'],
+    [
+      ...zeroArgTests,
+      '(/ (op 0 0) pi)',
+      '(/ (op 0 1) pi)',
+      '(/ (op 1 1) pi)',
+      '(/ (op 1 0) pi)',
+      '(/ (op 1 -1) pi)',
+      '(/ (op 0 -1) pi)',
+      '(/ (op -1 -1) pi)',
+      '(/ (op -1 0) pi)',
+      '(/ (op -1 1) pi)',
+      ...mixedTypesArgTests,
+    ]
+  ).toMatchInlineSnapshot(`
+    "
+    test              | atan
+    ---------------------------------------
+    (op)              | ERR
+    (/ (op 0 0) pi)   | 0
+    (/ (op 0 1) pi)   | 0
+    (/ (op 1 1) pi)   | 0.25
+    (/ (op 1 0) pi)   | 0.5
+    (/ (op 1 -1) pi)  | 0.75
+    (/ (op 0 -1) pi)  | 1
+    (/ (op -1 -1) pi) | -0.75
+    (/ (op -1 0) pi)  | -0.5
+    (/ (op -1 1) pi)  | -0.25
+    (op 0)            | 0
+    (op +inf.0)       | 1.5707963267948966
+    (op -inf.0)       | -1.5707963267948966
+    (op +nan.0)       | +nan.0
+    (op #f)           | ERR
+    (op #t)           | ERR
+    (op 'a)           | ERR
+    (op 0 0)          | 0
+    (op 1 0)          | 1.5707963267948966
+    (op 3 5)          | 0.5404195002705842
+    (op #f #f)        | ERR
+    (op #t #f)        | ERR
+    (op #f #t)        | ERR
+    (op #t #t)        | ERR
+    (op 'a 'a)        | ERR
+    (op 'a 'b)        | ERR
+    (op #f 0)         | ERR
+    (op 'a 0)         | ERR
+    (op 0 'a)         | ERR
+    (op 1 #t)         | ERR
+    (op 1 1 1 1)      | ERR
+    (op 1 2 3 4)      | ERR
+    (op #f #f #f)     | ERR
+    (op #f #f #f #f)  | ERR
+    (op #t #t #t)     | ERR
+    (op #t #f #t)     | ERR
+    (op 'a 'a 'a)     | ERR
+    (op 'a 'b 'b)     | ERR
+    (op 'a 'b 'c)     | ERR
+    (op 1 2 #t 1 'a)  | ERR
+    "
+  `);
 });
 
 test('boolean ops', () => {

--- a/src/__tests__/primitives.ts
+++ b/src/__tests__/primitives.ts
@@ -245,8 +245,75 @@ test('unary arithmetic ops', () => {
       'exp',
       'log',
     ],
-    []
-  ).toMatchInlineSnapshot(`""`);
+    [
+      ...zeroArgTests,
+      ...oneArgTests,
+      ...mixedTypesArgTests,
+      ...malformedArgTests,
+      ...oneListArgTests,
+    ]
+  ).toMatchInlineSnapshot(`
+    "
+    test              | zero? | positive? | negative? | round  | floor  | ceiling | truncate | sgn    | abs    | add1   | sub1   | exp                 | log
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    (op)              | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 0)            | #t    | #f        | #f        | 0      | 0      | 0       | 0        | 0      | 0      | 1      | -1     | 1                   | ERR
+    (op 1)            | #f    | #t        | #f        | 1      | 1      | 1       | 1        | 1      | 1      | 2      | 0      | 2.718281828459045   | 0
+    (op 2)            | #f    | #t        | #f        | 2      | 2      | 2       | 2        | 1      | 2      | 3      | 1      | 7.38905609893065    | 0.6931471805599453
+    (op 0.1)          | #f    | #t        | #f        | 0      | 0      | 1       | 0        | 1      | 0.1    | 1.1    | -0.9   | 1.1051709180756477  | -2.3025850929940455
+    (op 2.4)          | #f    | #t        | #f        | 2      | 2      | 3       | 2        | 1      | 2.4    | 3.4    | 1.4    | 11.023176380641601  | 0.8754687373538999
+    (op 2.5)          | #f    | #t        | #f        | 3      | 2      | 3       | 2        | 1      | 2.5    | 3.5    | 1.5    | 12.182493960703473  | 0.9162907318741551
+    (op 2.6)          | #f    | #t        | #f        | 3      | 2      | 3       | 2        | 1      | 2.6    | 3.6    | 1.6    | 13.463738035001692  | 0.9555114450274365
+    (op -2.4)         | #f    | #f        | #t        | -2     | -3     | -2      | -2       | -1     | 2.4    | -1.4   | -3.4   | 0.09071795328941251 | +nan.0
+    (op -2.5)         | #f    | #f        | #t        | -2     | -3     | -2      | -2       | -1     | 2.5    | -1.5   | -3.5   | 0.0820849986238988  | +nan.0
+    (op -2.6)         | #f    | #f        | #t        | -3     | -3     | -2      | -2       | -1     | 2.6    | -1.6   | -3.6   | 0.07427357821433388 | +nan.0
+    (op -1)           | #f    | #f        | #t        | -1     | -1     | -1      | -1       | -1     | 1      | 0      | -2     | 0.36787944117144233 | +nan.0
+    (op -2)           | #f    | #f        | #t        | -2     | -2     | -2      | -2       | -1     | 2      | -1     | -3     | 0.1353352832366127  | +nan.0
+    (op +inf.0)       | #f    | #t        | #f        | +inf.0 | +inf.0 | +inf.0  | +inf.0   | 1      | +inf.0 | +inf.0 | +inf.0 | +inf.0              | +inf.0
+    (op -inf.0)       | #f    | #f        | #t        | -inf.0 | -inf.0 | -inf.0  | -inf.0   | -1     | +inf.0 | -inf.0 | -inf.0 | 0                   | +nan.0
+    (op +nan.0)       | #f    | #f        | #f        | +nan.0 | +nan.0 | +nan.0  | +nan.0   | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0              | +nan.0
+    (op 0)            | #t    | #f        | #f        | 0      | 0      | 0       | 0        | 0      | 0      | 1      | -1     | 1                   | ERR
+    (op +inf.0)       | #f    | #t        | #f        | +inf.0 | +inf.0 | +inf.0  | +inf.0   | 1      | +inf.0 | +inf.0 | +inf.0 | +inf.0              | +inf.0
+    (op -inf.0)       | #f    | #f        | #t        | -inf.0 | -inf.0 | -inf.0  | -inf.0   | -1     | +inf.0 | -inf.0 | -inf.0 | 0                   | +nan.0
+    (op +nan.0)       | #f    | #f        | #f        | +nan.0 | +nan.0 | +nan.0  | +nan.0   | +nan.0 | +nan.0 | +nan.0 | +nan.0 | +nan.0              | +nan.0
+    (op #f)           | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #t)           | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 'a)           | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 0 0)          | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 1 0)          | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 3 5)          | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | 0.6826061944859853
+    (op #f #f)        | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #t #f)        | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #f #t)        | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #t #t)        | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 'a 'a)        | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 'a 'b)        | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #f 0)         | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 'a 0)         | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 0 'a)         | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 1 #t)         | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 1 1 1 1)      | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 1 2 3 4)      | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #f #f #f)     | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #f #f #f #f)  | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #t #t #t)     | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op #t #f #t)     | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 'a 'a 'a)     | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 'a 'b 'b)     | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 'a 'b 'c)     | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 1 2 #t 1 'a)  | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op 1 . 2)        | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op . 1)          | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op a)            | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op a a)          | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op ())           | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op '())          | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op '(1))         | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op '(1 2))       | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op '(1 2 3 4 5)) | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    (op '(1 #t))      | ERR   | ERR       | ERR       | ERR    | ERR    | ERR     | ERR      | ERR    | ERR    | ERR    | ERR    | ERR                 | ERR
+    "
+  `);
 });
 
 test('2 arg log', () => {

--- a/src/__tests__/primitives.ts
+++ b/src/__tests__/primitives.ts
@@ -170,7 +170,7 @@ export const oneListArgTests = [
 
 test('type predicates', () => {
   expectOpTable(
-    ['symbol?', 'number?', 'boolean?', 'null?', 'cons?', 'data?', 'nan?', 'infinite?'],
+    ['symbol?', 'number?', 'boolean?', 'null?', 'cons?', 'function?', 'nan?', 'infinite?'],
     []
   ).toMatchInlineSnapshot(`""`);
 });

--- a/src/__tests__/primitives.ts
+++ b/src/__tests__/primitives.ts
@@ -171,8 +171,61 @@ export const oneListArgTests = [
 test('type predicates', () => {
   expectOpTable(
     ['symbol?', 'number?', 'boolean?', 'null?', 'cons?', 'function?', 'nan?', 'infinite?'],
-    []
-  ).toMatchInlineSnapshot(`""`);
+    [
+      ...zeroArgTests,
+      ...mixedTypesArgTests,
+      ...oneListArgTests,
+
+      // test for 'function?'
+      '(op eq?)',
+      '(op function?)',
+      '(op (lambda (x) (f (f (f x)))))',
+    ]
+  ).toMatchInlineSnapshot(`
+    "
+    test                            | symbol? | number? | boolean? | null? | cons? | function? | nan? | infinite?
+    -------------------------------------------------------------------------------------------------------------
+    (op)                            | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 0)                          | #f      | #t      | #f       | #f    | #f    | #f        | #f   | #f
+    (op +inf.0)                     | #f      | #t      | #f       | #f    | #f    | #f        | #f   | #t
+    (op -inf.0)                     | #f      | #t      | #f       | #f    | #f    | #f        | #f   | #t
+    (op +nan.0)                     | #f      | #t      | #f       | #f    | #f    | #f        | #t   | #f
+    (op #f)                         | #f      | #f      | #t       | #f    | #f    | #f        | ERR  | ERR
+    (op #t)                         | #f      | #f      | #t       | #f    | #f    | #f        | ERR  | ERR
+    (op 'a)                         | #t      | #f      | #f       | #f    | #f    | #f        | ERR  | ERR
+    (op 0 0)                        | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 1 0)                        | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 3 5)                        | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #f #f)                      | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #t #f)                      | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #f #t)                      | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #t #t)                      | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 'a 'a)                      | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 'a 'b)                      | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #f 0)                       | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 'a 0)                       | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 0 'a)                       | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 1 #t)                       | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 1 1 1 1)                    | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 1 2 3 4)                    | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #f #f #f)                   | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #f #f #f #f)                | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #t #t #t)                   | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op #t #f #t)                   | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 'a 'a 'a)                   | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 'a 'b 'b)                   | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 'a 'b 'c)                   | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op 1 2 #t 1 'a)                | ERR     | ERR     | ERR      | ERR   | ERR   | ERR       | ERR  | ERR
+    (op '())                        | #f      | #f      | #f       | #t    | #f    | #f        | ERR  | ERR
+    (op '(1))                       | #f      | #f      | #f       | #f    | #t    | #f        | ERR  | ERR
+    (op '(1 2))                     | #f      | #f      | #f       | #f    | #t    | #f        | ERR  | ERR
+    (op '(1 2 3 4 5))               | #f      | #f      | #f       | #f    | #t    | #f        | ERR  | ERR
+    (op '(1 #t))                    | #f      | #f      | #f       | #f    | #t    | #f        | ERR  | ERR
+    (op eq?)                        | #f      | #f      | #f       | #f    | #f    | #t        | ERR  | ERR
+    (op function?)                  | #f      | #f      | #f       | #f    | #f    | #t        | ERR  | ERR
+    (op (lambda (x) (f (f (f x))))) | #f      | #f      | #f       | #f    | #f    | #t        | ERR  | ERR
+    "
+  `);
 });
 
 test('unary arithmetic ops', () => {

--- a/src/__tests__/primitives.ts
+++ b/src/__tests__/primitives.ts
@@ -316,8 +316,35 @@ test('unary arithmetic ops', () => {
   `);
 });
 
-test('2 arg log', () => {
-  expectOpTable(['log'], []).toMatchInlineSnapshot(`""`);
+test('2 args log', () => {
+  expectOpTable(['log'], [...twoNumArgTests]).toMatchInlineSnapshot(`
+    "
+    test               | log
+    ---------------------------------------
+    (op 0 0)           | ERR
+    (op 1 0)           | ERR
+    (op 0 1)           | ERR
+    (op 1 1)           | ERR
+    (op 3 5)           | 0.6826061944859853
+    (op 5 3)           | 1.4649735207179273
+    (op 0 +inf.0)      | ERR
+    (op 1 +inf.0)      | 0
+    (op 2 +inf.0)      | 0
+    (op +inf.0 0)      | ERR
+    (op +inf.0 1)      | ERR
+    (op +inf.0 2)      | +inf.0
+    (op +inf.0 +inf.0) | +nan.0
+    (op 0.1 0)         | ERR
+    (op 0 0.1)         | ERR
+    (op 0.1 0.1)       | 1
+    (op 0.3 0.5)       | 1.7369655941662063
+    (op 0.5 0.3)       | 0.5757166424934449
+    (op 3 5)           | 0.6826061944859853
+    (op -3 5)          | +nan.0
+    (op 3 -5)          | +nan.0
+    (op -3 -5)         | +nan.0
+    "
+  `);
 });
 
 test('exactly binary numeric ops', () => {

--- a/src/__tests__/primitives.ts
+++ b/src/__tests__/primitives.ts
@@ -254,41 +254,41 @@ test('2 arg log', () => {
 });
 
 test('exactly binary numeric ops', () => {
-  expectOpTable(['quotient', 'remainder', 'modulo', 'expt', 'log'], [...mixedTypesArgTests])
+  expectOpTable(['quotient', 'remainder', 'modulo', 'expt'], [...mixedTypesArgTests])
     .toMatchInlineSnapshot(`
     "
-    test             | quotient | remainder | modulo | expt | log
-    ----------------------------------------------------------------------------
-    (op 0)           | ERR      | ERR       | ERR    | ERR  | -inf.0
-    (op +inf.0)      | ERR      | ERR       | ERR    | ERR  | +inf.0
-    (op -inf.0)      | ERR      | ERR       | ERR    | ERR  | +nan.0
-    (op +nan.0)      | ERR      | ERR       | ERR    | ERR  | +nan.0
-    (op #f)          | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #t)          | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 'a)          | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 0 0)         | ERR      | ERR       | ERR    | 1    | +nan.0
-    (op 1 0)         | ERR      | ERR       | ERR    | 1    | 0
-    (op 3 5)         | 0        | 3         | 3      | 243  | 0.6826061944859853
-    (op #f #f)       | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #t #f)       | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #f #t)       | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #t #t)       | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 'a 'a)       | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 'a 'b)       | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #f 0)        | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 'a 0)        | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 0 'a)        | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 1 #t)        | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 1 1 1 1)     | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 1 2 3 4)     | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #f #f #f)    | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #f #f #f #f) | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #t #t #t)    | ERR      | ERR       | ERR    | ERR  | ERR
-    (op #t #f #t)    | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 'a 'a 'a)    | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 'a 'b 'b)    | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 'a 'b 'c)    | ERR      | ERR       | ERR    | ERR  | ERR
-    (op 1 2 #t 1 'a) | ERR      | ERR       | ERR    | ERR  | ERR
+    test             | quotient | remainder | modulo | expt
+    -------------------------------------------------------
+    (op 0)           | ERR      | ERR       | ERR    | ERR
+    (op +inf.0)      | ERR      | ERR       | ERR    | ERR
+    (op -inf.0)      | ERR      | ERR       | ERR    | ERR
+    (op +nan.0)      | ERR      | ERR       | ERR    | ERR
+    (op #f)          | ERR      | ERR       | ERR    | ERR
+    (op #t)          | ERR      | ERR       | ERR    | ERR
+    (op 'a)          | ERR      | ERR       | ERR    | ERR
+    (op 0 0)         | ERR      | ERR       | ERR    | 1
+    (op 1 0)         | ERR      | ERR       | ERR    | 1
+    (op 3 5)         | 0        | 3         | 3      | 243
+    (op #f #f)       | ERR      | ERR       | ERR    | ERR
+    (op #t #f)       | ERR      | ERR       | ERR    | ERR
+    (op #f #t)       | ERR      | ERR       | ERR    | ERR
+    (op #t #t)       | ERR      | ERR       | ERR    | ERR
+    (op 'a 'a)       | ERR      | ERR       | ERR    | ERR
+    (op 'a 'b)       | ERR      | ERR       | ERR    | ERR
+    (op #f 0)        | ERR      | ERR       | ERR    | ERR
+    (op 'a 0)        | ERR      | ERR       | ERR    | ERR
+    (op 0 'a)        | ERR      | ERR       | ERR    | ERR
+    (op 1 #t)        | ERR      | ERR       | ERR    | ERR
+    (op 1 1 1 1)     | ERR      | ERR       | ERR    | ERR
+    (op 1 2 3 4)     | ERR      | ERR       | ERR    | ERR
+    (op #f #f #f)    | ERR      | ERR       | ERR    | ERR
+    (op #f #f #f #f) | ERR      | ERR       | ERR    | ERR
+    (op #t #t #t)    | ERR      | ERR       | ERR    | ERR
+    (op #t #f #t)    | ERR      | ERR       | ERR    | ERR
+    (op 'a 'a 'a)    | ERR      | ERR       | ERR    | ERR
+    (op 'a 'b 'b)    | ERR      | ERR       | ERR    | ERR
+    (op 'a 'b 'c)    | ERR      | ERR       | ERR    | ERR
+    (op 1 2 #t 1 'a) | ERR      | ERR       | ERR    | ERR
     "
   `);
 });

--- a/src/__tests__/print-read-identity.ts
+++ b/src/__tests__/print-read-identity.ts
@@ -1,13 +1,13 @@
 import { read } from '../reader';
 import { print } from '../printer';
 import { SExpr } from '../sexpr';
-import { satom, snumber, sboolean, snil, scons, slist } from '../sexpr';
+import { ssymbol, snumber, sboolean, snil, scons, slist } from '../sexpr';
 import { equals } from '../sexpr';
 import { getOk } from '../utils';
 
 describe('print -> read identity', () => {
-  const a = satom('a');
-  const b = satom('b');
+  const a = ssymbol('a');
+  const b = ssymbol('b');
   const z = snumber(0);
   const s = snumber(6);
   const t = sboolean(true);

--- a/src/__tests__/print-read-identity.ts
+++ b/src/__tests__/print-read-identity.ts
@@ -15,10 +15,10 @@ describe('print -> read identity', () => {
   const n = snil();
 
   test.each([[a], [b], [z], [s], [t], [f], [n]] as SExpr[][])('values', (e: SExpr) => {
-    expect({ e, test: equals(getOk(read(print(e))), e) }).toEqual({
-      e,
-      test: true,
-    });
+    const ee = getOk(read(print(e)));
+    if (!equals(e, ee)) {
+      expect(ee).toBe(e);
+    }
   });
 
   test.each([
@@ -29,9 +29,9 @@ describe('print -> read identity', () => {
     [slist([a, b], slist([z, s], t))],
     [slist([a, slist([b, z, s], t)], f)],
   ] as SExpr[][])('lists', (e: SExpr) => {
-    expect({ e, test: equals(getOk(read(print(e))), e) }).toEqual({
-      e,
-      test: true,
-    });
+    const ee = getOk(read(print(e)));
+    if (!equals(e, ee)) {
+      expect(ee).toBe(e);
+    }
   });
 });

--- a/src/evaluator/__tests__/evaluator.ts
+++ b/src/evaluator/__tests__/evaluator.ts
@@ -171,6 +171,187 @@ describe('basic let blocks', () => {
       test_env()
     ).toMatchInlineSnapshot(`0`);
   });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(['let', [[1, ['+', 1, 2]]], 1], test_env());
+
+    expectJsonReadEvalError(['let', [['a', []]], 'a'], test_env());
+
+    expectJsonReadEvalError(['let', [['a', 1]], [], 'a'], test_env());
+
+    expectJsonReadEvalError(
+      [
+        'let',
+        [
+          ['a', 1],
+          ['b', 'a'],
+        ],
+        'b',
+      ],
+      test_env()
+    );
+  });
+});
+
+describe('basic let* blocks', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(
+      [
+        'let*',
+        [
+          ['a', 1],
+          ['b', 'a'],
+        ],
+        'b',
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(
+      [
+        'let*',
+        [
+          ['a', 1],
+          ['b', 'a'],
+        ],
+        'a',
+        'b',
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(
+      [
+        'let*',
+        [
+          ['a', 1],
+          [2, 'a'],
+        ],
+        2,
+      ],
+      test_env()
+    );
+
+    expectJsonReadEvalError(
+      [
+        'let*',
+        [
+          ['a', 1],
+          ['b', []],
+        ],
+        'a',
+      ],
+      test_env()
+    );
+
+    expectJsonReadEvalError(
+      [
+        'let*',
+        [
+          ['a', 1],
+          ['b', 'a'],
+        ],
+        ['a'],
+        'a',
+      ],
+      test_env()
+    );
+  });
+});
+
+describe('basic letrec blocks', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(
+      [
+        'letrec',
+        [
+          ['a', ['lambda', [], 'b']],
+          ['b', 1],
+        ],
+        ['a'],
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(
+      [
+        'letrec',
+        [
+          ['a', ['lambda', [], 'b']],
+          ['b', 1],
+        ],
+        ['a'],
+        'b',
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(
+      [
+        'letrec',
+        [
+          ['a', 1],
+          ['b', 'a'],
+        ],
+        'a',
+        'b',
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(
+      [
+        'letrec',
+        [
+          ['a', 'b'],
+          ['b', 1],
+        ],
+        'a',
+      ],
+      test_env()
+    );
+
+    expectJsonReadEvalError(
+      [
+        'letrec',
+        [
+          ['a', ['lambda', [], 'b']],
+          ['b', 1],
+        ],
+        [],
+        ['a'],
+      ],
+      test_env()
+    );
+
+    expectJsonReadEvalError(
+      [
+        'letrec',
+        [
+          [1, ['lambda', [], 'b']],
+          ['b', 1],
+        ],
+        ['a'],
+      ],
+      test_env()
+    );
+
+    expectJsonReadEvalError(
+      [
+        'letrec',
+        [
+          ['a', ['lambda', [], 'b']],
+          ['b', [1]],
+        ],
+        ['a'],
+      ],
+      test_env()
+    );
+  });
 });
 
 describe('basic lambda expressions', () => {

--- a/src/evaluator/__tests__/evaluator.ts
+++ b/src/evaluator/__tests__/evaluator.ts
@@ -94,13 +94,6 @@ describe('basic function calls', () => {
     ).toMatchInlineSnapshot(`25`);
   });
 
-  test("probably shouldn't be valid but uh...", () => {
-    expectJsonReadEvalPrint(
-      [['quote', ['primitive_function', '+']], 1, 2],
-      the_global_environment
-    ).toMatchInlineSnapshot(`3`);
-  });
-
   test('invalid', () => {
     expectJsonReadEvalError([], the_global_environment).toMatchInlineSnapshot(`undefined`);
     expectJsonReadEvalError([1], the_global_environment).toMatchInlineSnapshot(`undefined`);

--- a/src/evaluator/__tests__/evaluator.ts
+++ b/src/evaluator/__tests__/evaluator.ts
@@ -492,3 +492,83 @@ describe('basic begin0 expressions', () => {
     expectJsonReadEvalError(['begin0', 1, 2, [3]], test_env());
   });
 });
+
+describe('basic define constant', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(['begin', ['define', 'a', 1]], test_env()).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(['begin', ['define', 'a', 1], 'a'], test_env()).toMatchInlineSnapshot(
+      `1`
+    );
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(['begin', ['define', 'a']], test_env());
+
+    expectJsonReadEvalError(['begin', ['define', 1]], test_env());
+
+    expectJsonReadEvalError(['begin', ['define', 1, 1]], test_env());
+
+    expectJsonReadEvalError(['begin', ['define', 'a', []]], test_env());
+
+    expectJsonReadEvalError(['begin', 'nonexistent', ['define', 'nonexistent', 1]], test_env());
+  });
+});
+
+describe('basic define function', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(['begin', ['define', ['f'], 1]], test_env()).toHaveProperty('boxed');
+    expectJsonReadEvalPrint(['begin', ['define', ['f'], 1], 'f'], test_env()).toHaveProperty(
+      'boxed'
+    );
+
+    expectJsonReadEvalPrint(
+      ['begin', ['define', ['f'], 1], ['f']],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(
+      ['begin', ['define', ['f'], 1, 2], ['f']],
+      test_env()
+    ).toMatchInlineSnapshot(`2`);
+
+    expectJsonReadEvalPrint(['begin', ['define', ['f', 'x'], 'x']], test_env()).toHaveProperty(
+      'boxed'
+    );
+
+    expectJsonReadEvalPrint(['begin', ['define', ['f', 'x'], 'x'], 'f'], test_env()).toHaveProperty(
+      'boxed'
+    );
+
+    expectJsonReadEvalPrint(
+      ['begin', ['define', ['f', 'x'], 'x'], ['f', 1]],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(
+      ['begin', ['define', ['f', 'x', 'y'], ['+', 'x', 'y']], ['f', 1, 2]],
+      test_env()
+    ).toMatchInlineSnapshot(`3`);
+
+    expectJsonReadEvalPrint(
+      ['begin', ['define', ['f', 'x'], ['define', 'x1', ['+', 'x', 1]], 'x1'], ['f', 1]],
+      test_env()
+    ).toMatchInlineSnapshot(`2`);
+
+    expectJsonReadEvalPrint(['begin', ['define', ['f'], []], 'f'], test_env()).toHaveProperty(
+      'boxed'
+    );
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(['begin', ['define', [], 1]], test_env());
+
+    expectJsonReadEvalError(['begin', ['define', [1], 1]], test_env());
+
+    expectJsonReadEvalError(['begin', ['define', ['f', 1], 1]], test_env());
+
+    expectJsonReadEvalError(['begin', ['define', ['f']]], test_env());
+
+    expectJsonReadEvalError(['begin', ['define', ['f'], []], ['f']], test_env());
+  });
+});

--- a/src/evaluator/__tests__/evaluator.ts
+++ b/src/evaluator/__tests__/evaluator.ts
@@ -460,3 +460,35 @@ describe('basic cond expressions', () => {
     expectJsonReadEvalError(['cond', [false]], test_env()).toMatchInlineSnapshot(`undefined`);
   });
 });
+
+describe('basic begin expressions', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(['begin', 1], test_env()).toMatchInlineSnapshot(`1`);
+    expectJsonReadEvalPrint(['begin', 1, 2], test_env()).toMatchInlineSnapshot(`2`);
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(['begin', [1]], test_env());
+    expectJsonReadEvalError(['begin', [1], 2], test_env());
+    expectJsonReadEvalError(['begin', 1, [2]], test_env());
+    expectJsonReadEvalError(['begin', [1], 2, 3], test_env());
+    expectJsonReadEvalError(['begin', 1, [2], 3], test_env());
+    expectJsonReadEvalError(['begin', 1, 2, [3]], test_env());
+  });
+});
+
+describe('basic begin0 expressions', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(['begin0', 1], test_env()).toMatchInlineSnapshot(`1`);
+    expectJsonReadEvalPrint(['begin0', 1, 2], test_env()).toMatchInlineSnapshot(`1`);
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(['begin0', [1]], test_env());
+    expectJsonReadEvalError(['begin0', [1], 2], test_env());
+    expectJsonReadEvalError(['begin0', 1, [2]], test_env());
+    expectJsonReadEvalError(['begin0', [1], 2, 3], test_env());
+    expectJsonReadEvalError(['begin0', 1, [2], 3], test_env());
+    expectJsonReadEvalError(['begin0', 1, 2, [3]], test_env());
+  });
+});

--- a/src/evaluator/__tests__/evaluator.ts
+++ b/src/evaluator/__tests__/evaluator.ts
@@ -172,3 +172,71 @@ describe('basic let blocks', () => {
     ).toMatchInlineSnapshot(`0`);
   });
 });
+
+describe('basic lambda expressions', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(['lambda', ['x'], ['+', 1]], test_env());
+
+    expectJsonReadEvalPrint(['lambda', [], 1], test_env());
+
+    expectJsonReadEvalPrint([['lambda', [], 1]], test_env()).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(
+      [['lambda', ['x'], ['+', 'x', 1]], 1],
+      test_env()
+    ).toMatchInlineSnapshot(`2`);
+
+    expectJsonReadEvalPrint(
+      [['lambda', ['x', 'y'], ['+', 'x', 'y']], 1, 2],
+      test_env()
+    ).toMatchInlineSnapshot(`3`);
+
+    expectJsonReadEvalPrint(
+      [['lambda', ['x', 'y'], 'x', 'y', ['+', 'x', 'y']], 1, 2],
+      test_env()
+    ).toMatchInlineSnapshot(`3`);
+
+    expectJsonReadEvalPrint(
+      [
+        ['lambda', ['plus-one'], ['plus-one', 0]],
+        ['lambda', ['x'], ['+', 'x', 1]],
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(
+      [
+        ['lambda', ['plus-one', 'thrice'], [['thrice', 'plus-one'], 0]],
+        ['lambda', ['x'], ['+', 'x', 1]],
+        ['lambda', ['f'], ['lambda', ['x'], ['f', ['f', ['f', 'x']]]]],
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`3`);
+
+    expectJsonReadEvalPrint(
+      [
+        ['lambda', ['plus-one', 'thrice'], [['thrice', ['thrice', 'plus-one']], 0]],
+        ['lambda', ['x'], ['+', 'x', 1]],
+        ['lambda', ['f'], ['lambda', ['x'], ['f', ['f', ['f', 'x']]]]],
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`9`);
+
+    expectJsonReadEvalPrint(
+      [
+        ['lambda', ['plus-one', 'thrice'], [[['thrice', 'thrice'], 'plus-one'], 0]],
+        ['lambda', ['x'], ['+', 'x', 1]],
+        ['lambda', ['f'], ['lambda', ['x'], ['f', ['f', ['f', 'x']]]]],
+      ],
+      test_env()
+    ).toMatchInlineSnapshot(`27`);
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(['lambda', 'x', ['+', 1]], test_env());
+    expectJsonReadEvalError(['lambda', [1], ['+', 1]], test_env());
+    expectJsonReadEvalError([['lambda', ['x'], ['+', 'x', 'x']], 1, 2], test_env());
+    expectJsonReadEvalError([['lambda', ['f'], ['f', 1]], 1], test_env());
+    expectJsonReadEvalError([['lambda', ['f'], ['f', 1], 'f'], 1], test_env());
+  });
+});

--- a/src/evaluator/__tests__/evaluator.ts
+++ b/src/evaluator/__tests__/evaluator.ts
@@ -240,3 +240,42 @@ describe('basic lambda expressions', () => {
     expectJsonReadEvalError([['lambda', ['f'], ['f', 1], 'f'], 1], test_env());
   });
 });
+
+describe('basic cond expressions', () => {
+  test('valid', () => {
+    expectJsonReadEvalPrint(['cond', [true, 1]], test_env()).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(['cond', [true, 1], [true, 2]], test_env()).toMatchInlineSnapshot(`1`);
+
+    expectJsonReadEvalPrint(['cond', [false, 1], [true, 2]], test_env()).toMatchInlineSnapshot(`2`);
+
+    expectJsonReadEvalPrint(['cond', [true, 1, 2], [true, 3]], test_env()).toMatchInlineSnapshot(
+      `2`
+    );
+
+    expectJsonReadEvalPrint(['cond', [false], [true], [true, 1]], test_env()).toMatchInlineSnapshot(
+      `true`
+    );
+
+    expectJsonReadEvalPrint(
+      ['cond', [false], [false], [true, 1]],
+      test_env()
+    ).toMatchInlineSnapshot(`1`);
+  });
+
+  test('invalid', () => {
+    expectJsonReadEvalError(['cond', [[], 1]], test_env()).toMatchInlineSnapshot(`undefined`);
+
+    expectJsonReadEvalError(['cond', [true, '.', 1]], test_env()).toMatchInlineSnapshot(
+      `undefined`
+    );
+
+    expectJsonReadEvalError(['cond', [true, []]], test_env()).toMatchInlineSnapshot(`undefined`);
+
+    expectJsonReadEvalError(['cond', [true, [], 1]], test_env()).toMatchInlineSnapshot(`undefined`);
+
+    expectJsonReadEvalError(['cond'], test_env()).toMatchInlineSnapshot(`undefined`);
+
+    expectJsonReadEvalError(['cond', [false]], test_env()).toMatchInlineSnapshot(`undefined`);
+  });
+});

--- a/src/evaluator/__tests__/primitives.ts
+++ b/src/evaluator/__tests__/primitives.ts
@@ -62,7 +62,7 @@ describe('arithmetic primitives', () => {
   });
 
   test('valid -', () => {
-    expectJsonReadEvalPrint(['-', 1], the_global_environment).toMatchInlineSnapshot(`1`);
+    expectJsonReadEvalPrint(['-', 1], the_global_environment).toMatchInlineSnapshot(`-1`);
     expectJsonReadEvalPrint(['-', 1, 2], the_global_environment).toMatchInlineSnapshot(`-1`);
     expectJsonReadEvalPrint(['-', 1, 2, 3], the_global_environment).toMatchInlineSnapshot(`-4`);
     expectJsonReadEvalPrint(['-', 1, 2, 3, 4], the_global_environment).toMatchInlineSnapshot(`-8`);

--- a/src/evaluator/datatypes.ts
+++ b/src/evaluator/datatypes.ts
@@ -32,10 +32,6 @@ export const make_primitive = (fun: (...args: EvalValue[]) => EvalResult): Primi
   fun,
 });
 
-export function instanceOfEvalData(object: any): object is EvalData {
-  // (<any>EvalDataType) is adapted from https://blog.oio.de/2014/02/28/typescript-accessing-enum-values-via-a-string/
-  return Object.keys(EvalDataType).reduce(
-    (prev, curr) => object.variant === (<any>EvalDataType)[curr] || prev,
-    false
-  );
+export function is_function_variant(object: any): object is EvalData {
+  return object.variant === EvalDataType.Closure || object.variant === EvalDataType.Primitive;
 }

--- a/src/evaluator/datatypes.ts
+++ b/src/evaluator/datatypes.ts
@@ -1,0 +1,17 @@
+import { EvalValue, EvalResult } from './types';
+
+export enum EvalDataType {
+  Primitive,
+}
+
+export interface Primitive {
+  variant: EvalDataType.Primitive;
+  fun: (...args: EvalValue[]) => EvalResult;
+}
+
+export type EvalData = Primitive;
+
+export const make_primitive = (fun: (...args: EvalValue[]) => EvalResult): Primitive => ({
+  variant: EvalDataType.Primitive,
+  fun,
+});

--- a/src/evaluator/datatypes.ts
+++ b/src/evaluator/datatypes.ts
@@ -1,7 +1,17 @@
 import { EvalValue, EvalResult } from './types';
+import { Environment } from './environment';
+import { SExpr } from '../sexpr';
 
 export enum EvalDataType {
+  Closure,
   Primitive,
+}
+
+export interface Closure {
+  variant: EvalDataType.Closure;
+  env: Environment | undefined;
+  params: string[];
+  body: SExpr[];
 }
 
 export interface Primitive {
@@ -9,7 +19,13 @@ export interface Primitive {
   fun: (...args: EvalValue[]) => EvalResult;
 }
 
-export type EvalData = Primitive;
+export type EvalData = Closure | Primitive;
+
+export const make_closure = (
+  env: Environment | undefined,
+  params: string[],
+  body: SExpr[]
+): Closure => ({ variant: EvalDataType.Closure, env, params, body });
 
 export const make_primitive = (fun: (...args: EvalValue[]) => EvalResult): Primitive => ({
   variant: EvalDataType.Primitive,

--- a/src/evaluator/datatypes.ts
+++ b/src/evaluator/datatypes.ts
@@ -31,3 +31,11 @@ export const make_primitive = (fun: (...args: EvalValue[]) => EvalResult): Primi
   variant: EvalDataType.Primitive,
   fun,
 });
+
+export function instanceOfEvalData(object: any): object is EvalData {
+  // (<any>EvalDataType) is adapted from https://blog.oio.de/2014/02/28/typescript-accessing-enum-values-via-a-string/
+  return Object.keys(EvalDataType).reduce(
+    (prev, curr) => object.variant === (<any>EvalDataType)[curr] || prev,
+    false
+  );
+}

--- a/src/evaluator/environment.ts
+++ b/src/evaluator/environment.ts
@@ -1,6 +1,6 @@
 import { EvalValue } from './types';
 
-export type Bindings = Record<string, EvalValue>;
+export type Bindings = Record<string, EvalValue | undefined>;
 
 export interface Environment {
   bindings: Bindings;

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -6,19 +6,33 @@ import { EvalDataType, make_closure, make_primitive } from './datatypes';
 import { EvalValue, Evaluate, Apply, EvalResult } from './types';
 import { Bindings, Environment, make_env, make_env_list, find_env } from './environment';
 
-import { primitives } from './primitives';
+import { primitive_consts, primitive_funcs } from './primitives';
 
 import { match_special_form, MatchType, SpecialFormType } from './special-form';
 import { MatchObject } from '../pattern';
 
-const primitives_bindings: Bindings = Object.entries(primitives).reduce((obj, [name, fun]) => {
-  obj[name] = sbox(make_primitive(fun));
-  return obj;
-}, {});
+const primitive_funcs_bindings: Bindings = Object.entries(primitive_funcs).reduce(
+  (obj, [name, fun]) => {
+    obj[name] = sbox(make_primitive(fun));
+    return obj;
+  },
+  {}
+);
+
+const primitive_consts_bindings: Bindings = Object.entries(primitive_consts).reduce(
+  (obj, [name, c]) => {
+    obj[name] = c;
+    return obj;
+  },
+  {}
+);
 
 export { Environment, make_env, make_env_list };
 
-export const the_global_environment: Environment = make_env_list(primitives_bindings);
+export const the_global_environment: Environment = make_env_list(
+  primitive_funcs_bindings,
+  primitive_consts_bindings
+);
 
 export type SpecialFormEvaluator = (
   matches: MatchObject,

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -25,6 +25,27 @@ export type SpecialFormEvaluator = (
   env: Environment | undefined
 ) => EvalResult;
 const special_form_evaluators: Record<SpecialFormType, SpecialFormEvaluator> = {
+  begin: ({ body }: MatchObject, env: Environment | undefined): EvalResult => {
+    let r: EvalResult;
+    for (const expr of body) {
+      r = evaluate(expr, env);
+      if (isBadResult(r)) {
+        return r;
+      }
+    }
+    return r!;
+  },
+  begin0: ({ body }: MatchObject, env: Environment | undefined): EvalResult => {
+    const it = body[Symbol.iterator]();
+    const r = evaluate(it.next().value, env);
+    for (const expr of it) {
+      const rr = evaluate(expr, env);
+      if (isBadResult(rr)) {
+        return rr;
+      }
+    }
+    return r;
+  },
   cond: ({ test_exprs, then_bodies }: MatchObject, env: Environment | undefined): EvalResult => {
     for (let i = 0; i < test_exprs.length; i++) {
       const r: EvalResult = evaluate(test_exprs[i], env);

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1,7 +1,7 @@
 import { err, ok, isBadResult } from '../utils';
-import { satom, snil, slist, SExpr } from '../sexpr';
+import { ssymbol, snil, slist, SExpr } from '../sexpr';
 import { val, car, cdr } from '../sexpr';
-import { is_atom, is_value, is_list, is_nil } from '../sexpr';
+import { is_symbol, is_value, is_list, is_nil } from '../sexpr';
 import { EvalValue, Evaluate, Apply, EvalResult } from './types';
 import { Bindings, Environment, make_env, make_env_list, find_env } from './environment';
 
@@ -11,7 +11,7 @@ import { match_special_form, MatchType, SpecialForms } from './special-form';
 import { MatchObject } from '../pattern';
 
 const primitives_bindings: Bindings = Object.entries(primitives).reduce((obj, [name, _]) => {
-  obj[name] = slist([satom('primitive_function'), satom(name)], snil());
+  obj[name] = slist([ssymbol('primitive_function'), ssymbol(name)], snil());
   return obj;
 }, {});
 
@@ -28,7 +28,7 @@ const special_form_evaluators: Record<SpecialForms, SpecialFormEvaluator> = {
     const bindings: Bindings = {};
     for (let i = 0; i < val_exprs.length; i++) {
       const id = ids[i];
-      if (!is_atom(id)) {
+      if (!is_symbol(id)) {
         return err();
       }
       const val_r = evaluate(val_exprs[i], env);
@@ -54,7 +54,7 @@ const apply: Apply = (fun, ...args) => {
     return err();
   }
   const fun_type = car(fun);
-  if (!is_atom(fun_type)) {
+  if (!is_symbol(fun_type)) {
     // not in the right format for a function
     return err();
   }
@@ -65,11 +65,11 @@ const apply: Apply = (fun, ...args) => {
     if (!is_list(rest)) {
       return err();
     }
-    const prim_name_atom = car(rest);
-    if (!is_atom(prim_name_atom)) {
+    const prim_name_symbol = car(rest);
+    if (!is_symbol(prim_name_symbol)) {
       return err();
     }
-    const prim_name = val(prim_name_atom);
+    const prim_name = val(prim_name_symbol);
     if (!(prim_name in primitives)) {
       return err();
     }
@@ -86,7 +86,7 @@ export const evaluate: Evaluate = (program, env) => {
   }
 
   // Variable references
-  if (is_atom(program)) {
+  if (is_symbol(program)) {
     const name = val(program);
     const binding_env = find_env(name, env);
     if (binding_env === undefined) {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -8,7 +8,7 @@ import { Bindings, Environment, make_env, make_env_list, find_env } from './envi
 
 import { primitives } from './primitives';
 
-import { match_special_form, MatchType, SpecialForms } from './special-form';
+import { match_special_form, MatchType, SpecialFormType } from './special-form';
 import { MatchObject } from '../pattern';
 
 const primitives_bindings: Bindings = Object.entries(primitives).reduce((obj, [name, fun]) => {
@@ -24,7 +24,7 @@ export type SpecialFormEvaluator = (
   matches: MatchObject,
   env: Environment | undefined
 ) => EvalResult;
-const special_form_evaluators: Record<SpecialForms, SpecialFormEvaluator> = {
+const special_form_evaluators: Record<SpecialFormType, SpecialFormEvaluator> = {
   let: ({ ids, val_exprs, bodies }: MatchObject, env: Environment | undefined): EvalResult => {
     const bindings: Bindings = {};
     for (let i = 0; i < val_exprs.length; i++) {

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -16,7 +16,7 @@ const primitive_funcs_bindings: Bindings = Object.entries(primitive_funcs).reduc
     obj[name] = sbox(make_primitive(fun));
     return obj;
   },
-  {}
+  {} as Record<string, EvalValue>
 );
 
 const primitive_consts_bindings: Bindings = Object.entries(primitive_consts).reduce(
@@ -24,7 +24,7 @@ const primitive_consts_bindings: Bindings = Object.entries(primitive_consts).red
     obj[name] = c;
     return obj;
   },
-  {}
+  {} as Record<string, EvalValue>
 );
 
 export { Environment, make_env, make_env_list };

--- a/src/evaluator/primitives.ts
+++ b/src/evaluator/primitives.ts
@@ -3,7 +3,7 @@ import { equals, sboolean, scons, slist, snil, SNumber, snumber, val } from '../
 import { is_symbol, is_number, is_boolean, is_nil, is_list, is_boxed } from '../sexpr';
 import { car, cdr } from '../sexpr';
 import { EvalValue, EvalResult } from './types';
-import { instanceOfEvalData } from './datatypes';
+import { is_function_variant } from './datatypes';
 
 export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResult> = {
   'eq?': (...args) => {
@@ -115,7 +115,7 @@ export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResul
       return err();
     }
     const [arg] = args;
-    return ok(sboolean(is_boxed(arg) && instanceOfEvalData(arg.val)));
+    return ok(sboolean(is_boxed(arg) && is_function_variant(arg.val)));
   },
 
   'zero?': (...args) => {

--- a/src/evaluator/primitives.ts
+++ b/src/evaluator/primitives.ts
@@ -530,7 +530,7 @@ export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResul
       return err();
     }
     const [arg] = args;
-    return !is_number(arg) ? err() : ok(sboolean(!Number.isFinite(val(arg))));
+    return !is_number(arg) ? err() : ok(sboolean(!Number.isFinite(val(arg)) && !Number.isNaN(val(arg))));
   },
 
   and: (...args) => {

--- a/src/evaluator/primitives.ts
+++ b/src/evaluator/primitives.ts
@@ -1,10 +1,143 @@
 import { err, ok } from '../utils';
-import { snumber, val } from '../sexpr';
-import { is_number, is_list } from '../sexpr';
+import { equals, sboolean, scons, slist, snil, SNumber, snumber, val } from '../sexpr';
+import { is_symbol, is_number, is_boolean, is_nil, is_list, is_boxed } from '../sexpr';
 import { car, cdr } from '../sexpr';
 import { EvalValue, EvalResult } from './types';
 
-export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = {
+export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResult> = {
+  'eq?': (...args) => {
+    for (let i = 0; i < args.length - 1; i++) {
+      const lhs = args[i];
+      const rhs = args[i + 1];
+      if (
+        !(
+          (is_symbol(lhs) && is_symbol(rhs) && val(lhs) === val(rhs)) ||
+          (is_number(lhs) && is_number(rhs) && val(lhs) === val(rhs)) ||
+          (is_boolean(lhs) && is_boolean(rhs) && val(lhs) === val(rhs)) ||
+          (is_nil(lhs) && is_nil(rhs)) ||
+          (is_list(lhs) && is_list(rhs) && lhs === rhs)
+        )
+      ) {
+        return ok(sboolean(false));
+      }
+    }
+    return ok(sboolean(true));
+  },
+  'equal?': (...args) => {
+    for (let i = 0; i < args.length - 1; i++) {
+      const lhs = args[i];
+      const rhs = args[i + 1];
+      if (!equals(lhs, rhs)) {
+        return ok(sboolean(false));
+      }
+    }
+    return ok(sboolean(true));
+  },
+  'symbol=?': (...args) => {
+    if (!args.every(is_symbol)) {
+      return ok(sboolean(false));
+    }
+    for (let i = 0; i < args.length - 1; i++) {
+      const lhs = args[i];
+      const rhs = args[i + 1];
+      if (val(lhs) !== val(rhs)) {
+        return ok(sboolean(false));
+      }
+    }
+    return ok(sboolean(true));
+  },
+  'number=?': (...args) => {
+    if (!args.every(is_number)) {
+      return ok(sboolean(false));
+    }
+    for (let i = 0; i < args.length - 1; i++) {
+      const lhs = args[i];
+      const rhs = args[i + 1];
+      if (val(lhs) !== val(rhs)) {
+        return ok(sboolean(false));
+      }
+    }
+    return ok(sboolean(true));
+  },
+  'boolean=?': (...args) => {
+    if (!args.every(is_boolean)) {
+      return ok(sboolean(false));
+    }
+    for (let i = 0; i < args.length - 1; i++) {
+      const lhs = args[i];
+      const rhs = args[i + 1];
+      if (val(lhs) !== val(rhs)) {
+        return ok(sboolean(false));
+      }
+    }
+    return ok(sboolean(true));
+  },
+
+  'symbol?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return ok(sboolean(is_symbol(arg)));
+  },
+  'number?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return ok(sboolean(is_number(arg)));
+  },
+  'boolean?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return ok(sboolean(is_boolean(arg)));
+  },
+  'null?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return ok(sboolean(is_nil(arg)));
+  },
+  'cons?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return ok(sboolean(is_list(arg)));
+  },
+  'data?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return ok(sboolean(is_boxed(arg)));
+  },
+
+  'zero?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(sboolean(val(arg) === 0));
+  },
+  'positive?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(sboolean(val(arg) > 0));
+  },
+  'negative?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(sboolean(val(arg) < 0));
+  },
+
   '+': (...args) => {
     let x = 0;
     for (const arg of args) {
@@ -31,6 +164,14 @@ export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = 
     if (args.length === 0) {
       return err();
     }
+    if (args.length === 1) {
+      const first = args[0];
+      if (is_number(first)) {
+        return ok(snumber(0 - val(first)));
+      } else {
+        return err();
+      }
+    }
     const it = args[Symbol.iterator]();
     const first = it.next().value;
     let x: number;
@@ -52,6 +193,17 @@ export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = 
     if (args.length === 0) {
       return err();
     }
+    if (args.length === 1) {
+      const first = args[0];
+      if (is_number(first)) {
+        if (val(first) === 0) {
+          return err();
+        }
+        return ok(snumber(1 / val(first)));
+      } else {
+        return err();
+      }
+    }
     const it = args[Symbol.iterator]();
     const first = it.next().value;
     let x: number;
@@ -62,6 +214,9 @@ export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = 
     }
     for (const arg of it) {
       if (is_number(arg)) {
+        if (val(arg) === 0) {
+          return err();
+        }
         x /= val(arg);
       } else {
         return err();
@@ -69,7 +224,384 @@ export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = 
     }
     return ok(snumber(x));
   },
+  quotient: (...args) => {
+    if (args.length !== 2 || !args.every(is_number)) {
+      return err();
+    }
+    const [n, m] = args;
+    if (val(m) === 0) {
+      return err();
+    }
+    return ok(snumber(Math.trunc(val(n) / val(m))));
+  },
+  remainder: (...args) => {
+    if (args.length !== 2 || !args.every(is_number)) {
+      return err();
+    }
+    const [n, m] = args;
+    if (val(m) === 0) {
+      return err();
+    }
+    return ok(snumber(val(n) % val(m)));
+  },
+  modulo: (...args) => {
+    if (args.length !== 2 || !args.every(is_number)) {
+      return err();
+    }
+    const [n, m] = args;
+    const vn = val(n);
+    const vm = val(m);
+    if (vm === 0) {
+      return err();
+    }
+    const rem = vn % vm;
+    if (rem === 0) {
+      return ok(snumber(0));
+    }
+    if (vn > 0 !== vm > 0) {
+      return ok(snumber((vn % vm) + vm));
+    } else {
+      return ok(snumber(vn % vm));
+    }
+  },
 
+  round: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.round(val(arg))));
+  },
+  floor: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.floor(val(arg))));
+  },
+  ceiling: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.ceil(val(arg))));
+  },
+  truncate: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.trunc(val(arg))));
+  },
+
+  sgn: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.sign(val(arg))));
+  },
+  abs: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.abs(val(arg))));
+  },
+  max: (...args) => {
+    if (!args.every(is_number)) {
+      return err();
+    }
+    return ok(snumber(Math.max(...(args.map(val) as number[]))));
+  },
+  min: (...args) => {
+    if (!args.every(is_number)) {
+      return err();
+    }
+    return ok(snumber(Math.min(...(args.map(val) as number[]))));
+  },
+  add1: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(val(arg) + 1));
+  },
+  sub1: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(val(arg) - 1));
+  },
+  expt: (...args) => {
+    if (args.length !== 2) {
+      return err();
+    }
+    const [x, n] = args;
+    return !is_number(x) || !is_number(n) ? err() : ok(snumber(Math.pow(val(x), val(n))));
+  },
+  exp: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.exp(val(arg))));
+  },
+  log: (...args) => {
+    if (args.length !== 1 && args.length !== 2) {
+      return err();
+    }
+    const [arg, base] = args;
+    if (base) {
+      return !is_number(arg) || !is_number(base)
+        ? err()
+        : ok(snumber(Math.log(val(arg)) / Math.log(val(base))));
+    } else {
+      return !is_number(arg) ? err() : ok(snumber(Math.log(val(arg))));
+    }
+  },
+
+  sin: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.sin(val(arg))));
+  },
+  cos: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.cos(val(arg))));
+  },
+  tan: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.tan(val(arg))));
+  },
+  asin: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.asin(val(arg))));
+  },
+  acos: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.acos(val(arg))));
+  },
+  atan: (...args) => {
+    if (args.length !== 1 && args.length !== 2) {
+      return err();
+    }
+    const [x, y] = args;
+    if (y) {
+      return !is_number(x) || !is_number(y) ? err() : ok(snumber(Math.atan2(val(x), val(y))));
+    } else {
+      return !is_number(x) ? err() : ok(snumber(Math.atan(val(x))));
+    }
+  },
+  sinh: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.sinh(val(arg))));
+  },
+  cosh: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.cosh(val(arg))));
+  },
+  tanh: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(snumber(Math.tanh(val(arg))));
+  },
+
+  '=': (...args) => {
+    if (args.length === 0) {
+      return err();
+    }
+    if (!args.every(is_number)) {
+      return err();
+    }
+    const it = args[Symbol.iterator]();
+    const z = val(it.next().value as SNumber);
+    for (const w of it) {
+      if (z !== val(w)) {
+        return ok(sboolean(false));
+      }
+    }
+    return ok(sboolean(true));
+  },
+  '<': (...args) => {
+    if (args.length === 0) {
+      return err();
+    }
+    if (!args.every(is_number)) {
+      return err();
+    }
+    const it = args[Symbol.iterator]();
+    let z = val(it.next().value as SNumber);
+    for (const w of it) {
+      const wv = val(w);
+      if (z >= wv) {
+        return ok(sboolean(false));
+      }
+      z = wv;
+    }
+    return ok(sboolean(true));
+  },
+  '>': (...args) => {
+    if (args.length === 0) {
+      return err();
+    }
+    if (!args.every(is_number)) {
+      return err();
+    }
+    const it = args[Symbol.iterator]();
+    let z = val(it.next().value as SNumber);
+    for (const w of it) {
+      const wv = val(w);
+      if (z <= wv) {
+        return ok(sboolean(false));
+      }
+      z = wv;
+    }
+    return ok(sboolean(true));
+  },
+  '<=': (...args) => {
+    if (args.length === 0) {
+      return err();
+    }
+    if (!args.every(is_number)) {
+      return err();
+    }
+    const it = args[Symbol.iterator]();
+    let z = val(it.next().value as SNumber);
+    for (const w of it) {
+      const wv = val(w);
+      if (z > wv) {
+        return ok(sboolean(false));
+      }
+      z = wv;
+    }
+    return ok(sboolean(true));
+  },
+  '>=': (...args) => {
+    if (args.length === 0) {
+      return err();
+    }
+    if (!args.every(is_number)) {
+      return err();
+    }
+    const it = args[Symbol.iterator]();
+    let z = val(it.next().value as SNumber);
+    for (const w of it) {
+      const wv = val(w);
+      if (z < wv) {
+        return ok(sboolean(false));
+      }
+      z = wv;
+    }
+    return ok(sboolean(true));
+  },
+  'nan?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(sboolean(Number.isNaN(val(arg))));
+  },
+  'infinite?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_number(arg) ? err() : ok(sboolean(!Number.isFinite(val(arg))));
+  },
+
+  and: (...args) => {
+    if (!args.every(is_boolean)) {
+      return err();
+    }
+    return ok(sboolean(args.reduce((prev, a) => prev && val(a), true)));
+  },
+  or: (...args) => {
+    if (!args.every(is_boolean)) {
+      return err();
+    }
+    return ok(sboolean(args.reduce((prev, a) => prev || val(a), false)));
+  },
+  not: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_boolean(arg) ? err() : ok(sboolean(!val(arg)));
+  },
+  nand: (...args) => {
+    if (!args.every(is_boolean)) {
+      return err();
+    }
+    return ok(sboolean(!args.reduce((prev, a) => prev && val(a), true)));
+  },
+  nor: (...args) => {
+    if (!args.every(is_boolean)) {
+      return err();
+    }
+    return ok(sboolean(!args.reduce((prev, a) => prev || val(a), false)));
+  },
+  xor: (...args) => {
+    if (!args.every(is_boolean)) {
+      return err();
+    }
+    return ok(sboolean(args.reduce((prev, a) => prev !== val(a), false)));
+  },
+  implies: (...args) => {
+    if (args.length !== 2) {
+      return err();
+    }
+    const [p, q] = args;
+    return !is_boolean(p) || !is_boolean(q) ? err() : ok(sboolean(!val(p) || val(q)));
+  },
+  'false?': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    return !is_boolean(arg) ? err() : ok(sboolean(!val(arg)));
+  },
+
+  cons: (...args) => {
+    if (args.length !== 2) {
+      return err();
+    }
+    const [x, y] = args;
+    return ok(scons(x, y));
+  },
+  list: (...args) => {
+    return ok(slist(args, snil()));
+  },
+  'list*': (...args) => {
+    if (args.length === 0) {
+      return err();
+    }
+    const last = args.pop()!;
+    return ok(slist(args, last));
+  },
   car: (...args) => {
     if (args.length !== 1) {
       return err();
@@ -80,7 +612,6 @@ export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = 
     }
     return ok(car(arg));
   },
-
   cdr: (...args) => {
     if (args.length !== 1) {
       return err();
@@ -91,4 +622,61 @@ export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = 
     }
     return ok(cdr(arg));
   },
+  first: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    if (!is_list(arg)) {
+      return err();
+    }
+    return ok(car(arg));
+  },
+  rest: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    const [arg] = args;
+    if (!is_list(arg)) {
+      return err();
+    }
+    return ok(cdr(arg));
+  },
+  last: (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    let last_pair = args[0];
+    if (!is_list(last_pair)) {
+      return err();
+    }
+    let tail = cdr(last_pair);
+    while (is_list(tail)) {
+      last_pair = tail;
+      tail = cdr(tail);
+    }
+    return ok(car(last_pair));
+  },
+  'last-pair': (...args) => {
+    if (args.length !== 1) {
+      return err();
+    }
+    let last_pair = args[0];
+    if (!is_list(last_pair)) {
+      return err();
+    }
+    let tail = cdr(last_pair);
+    while (is_list(tail)) {
+      last_pair = tail;
+      tail = cdr(tail);
+    }
+    return ok(last_pair);
+  },
+};
+
+export const primitive_consts: Record<string, EvalValue> = {
+  pi: snumber(Math.PI),
+  e: snumber(Math.E),
+  true: sboolean(true),
+  false: sboolean(false),
 };

--- a/src/evaluator/primitives.ts
+++ b/src/evaluator/primitives.ts
@@ -80,6 +80,7 @@ export const primitives: Record<string, (...args: EvalValue[]) => EvalResult> = 
     }
     return ok(car(arg));
   },
+
   cdr: (...args) => {
     if (args.length !== 1) {
       return err();

--- a/src/evaluator/primitives.ts
+++ b/src/evaluator/primitives.ts
@@ -3,6 +3,7 @@ import { equals, sboolean, scons, slist, snil, SNumber, snumber, val } from '../
 import { is_symbol, is_number, is_boolean, is_nil, is_list, is_boxed } from '../sexpr';
 import { car, cdr } from '../sexpr';
 import { EvalValue, EvalResult } from './types';
+import { instanceOfEvalData } from './datatypes';
 
 export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResult> = {
   'eq?': (...args) => {
@@ -108,12 +109,13 @@ export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResul
     const [arg] = args;
     return ok(sboolean(is_list(arg)));
   },
-  'data?': (...args) => {
+
+  'function?': (...args) => {
     if (args.length !== 1) {
       return err();
     }
     const [arg] = args;
-    return ok(sboolean(is_boxed(arg)));
+    return ok(sboolean(is_boxed(arg) && instanceOfEvalData(arg.val)));
   },
 
   'zero?': (...args) => {
@@ -530,7 +532,9 @@ export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResul
       return err();
     }
     const [arg] = args;
-    return !is_number(arg) ? err() : ok(sboolean(!Number.isFinite(val(arg)) && !Number.isNaN(val(arg))));
+    return !is_number(arg)
+      ? err()
+      : ok(sboolean(!Number.isFinite(val(arg)) && !Number.isNaN(val(arg))));
   },
 
   and: (...args) => {

--- a/src/evaluator/primitives.ts
+++ b/src/evaluator/primitives.ts
@@ -356,11 +356,15 @@ export const primitive_funcs: Record<string, (...args: EvalValue[]) => EvalResul
     }
     const [arg, base] = args;
     if (base) {
+      // val(base) === 0 is manually checked as log 0 in the denominator should raise exception
+      // But the Javascript Math.log(0) returns -Infinity instead and causing division with it to return 0
       return !is_number(arg) || !is_number(base)
+        ? err()
+        : val(arg) === 0 || val(base) === 1 || val(base) === 0
         ? err()
         : ok(snumber(Math.log(val(arg)) / Math.log(val(base))));
     } else {
-      return !is_number(arg) ? err() : ok(snumber(Math.log(val(arg))));
+      return !is_number(arg) || val(arg) === 0 ? err() : ok(snumber(Math.log(val(arg))));
     }
   },
 

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -6,6 +6,7 @@ import { jsonRead } from '../sexpr';
 import { hasKey } from '../utils';
 
 export type SpecialFormKeywordToType = {
+  cond: 'cond';
   lambda: 'lambda';
   let: 'let';
   quote: 'quote';
@@ -21,6 +22,16 @@ export interface Form {
 }
 
 export const special_forms: Record<SpecialFormKeywords, Form[]> = {
+  cond: [
+    {
+      pattern: jsonRead([
+        'cond',
+        '.',
+        json_plus([json_var('test_exprs'), '.', json_var('then_bodies')], []),
+      ]),
+      form: 'cond',
+    },
+  ],
   lambda: [
     {
       pattern: jsonRead([

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -15,6 +15,8 @@ type SpecialFormKeywordToType = {
   'let*': 'let*';
   letrec: 'letrec';
   quote: 'quote';
+  quasiquote: 'quasiquote';
+  unquote: 'unquote';
 };
 
 export type SpecialFormKeywords = keyof SpecialFormKeywordToType;
@@ -114,6 +116,18 @@ export const special_forms: Record<SpecialFormKeywords, Form[]> = {
     {
       pattern: jsonRead(['quote', json_var('e')]),
       form: 'quote',
+    },
+  ],
+  quasiquote: [
+    {
+      pattern: jsonRead(['quasiquote', json_var('e')]),
+      form: 'quasiquote',
+    },
+  ],
+  unquote: [
+    {
+      pattern: jsonRead(['unquote', json_var('e')]),
+      form: 'unquote',
     },
   ],
 };

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -21,6 +21,8 @@ export type SpecialFormKeywords = keyof SpecialFormKeywordToType;
 
 export type SpecialFormType = SpecialFormKeywordToType[SpecialFormKeywords];
 
+export type SpecialForms = SpecialFormKeywords;
+
 export interface Form {
   pattern: Pattern;
   form: SpecialFormType;

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -6,6 +6,7 @@ import { jsonRead } from '../sexpr';
 import { hasKey } from '../utils';
 
 type SpecialFormKeywordToType = {
+  define: 'define_const' | 'define_func';
   begin: 'begin';
   begin0: 'begin0';
   cond: 'cond';
@@ -26,6 +27,21 @@ export interface Form {
 }
 
 export const special_forms: Record<SpecialFormKeywords, Form[]> = {
+  define: [
+    {
+      pattern: jsonRead([
+        'define',
+        [json_var('fun_name'), '.', json_star(json_var('params'), [])],
+        '.',
+        json_plus(json_var('body'), []),
+      ]),
+      form: 'define_func',
+    },
+    {
+      pattern: jsonRead(['define', json_var('id'), json_var('expr')]),
+      form: 'define_const',
+    },
+  ],
   begin: [
     {
       pattern: jsonRead(['begin', '.', json_plus(json_var('body'), [])]),

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -6,6 +6,7 @@ import { jsonRead } from '../sexpr';
 import { hasKey } from '../utils';
 
 export type SpecialFormKeywordToType = {
+  lambda: 'lambda';
   let: 'let';
   quote: 'quote';
 };
@@ -20,6 +21,17 @@ export interface Form {
 }
 
 export const special_forms: Record<SpecialFormKeywords, Form[]> = {
+  lambda: [
+    {
+      pattern: jsonRead([
+        'lambda',
+        json_star(json_var('params'), []),
+        '.',
+        json_plus(json_var('body'), []),
+      ]),
+      form: 'lambda',
+    },
+  ],
   let: [
     {
       pattern: jsonRead([

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -1,7 +1,7 @@
 import { MatchObject, json_plus, json_star, json_var, match, Pattern } from '../pattern';
 import { SList } from '../sexpr';
 import { val, car } from '../sexpr';
-import { is_atom } from '../sexpr';
+import { is_symbol } from '../sexpr';
 import { jsonRead } from '../sexpr';
 
 export type SpecialForms = 'let' | 'quote';
@@ -44,7 +44,7 @@ export type MatchResult =
 
 export function match_special_form(program: SList<never>): MatchResult {
   const head = car(program);
-  if (!is_atom(head)) {
+  if (!is_symbol(head)) {
     return { match_type: MatchType.NoMatch, form: undefined, matches: undefined };
   }
   const keyword = val(head);

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -5,7 +5,9 @@ import { is_symbol } from '../sexpr';
 import { jsonRead } from '../sexpr';
 import { hasKey } from '../utils';
 
-export type SpecialFormKeywordToType = {
+type SpecialFormKeywordToType = {
+  begin: 'begin';
+  begin0: 'begin0';
   cond: 'cond';
   lambda: 'lambda';
   let: 'let';
@@ -24,6 +26,18 @@ export interface Form {
 }
 
 export const special_forms: Record<SpecialFormKeywords, Form[]> = {
+  begin: [
+    {
+      pattern: jsonRead(['begin', '.', json_plus(json_var('body'), [])]),
+      form: 'begin',
+    },
+  ],
+  begin0: [
+    {
+      pattern: jsonRead(['begin0', '.', json_plus(json_var('body'), [])]),
+      form: 'begin0',
+    },
+  ],
   cond: [
     {
       pattern: jsonRead([

--- a/src/evaluator/special-form.ts
+++ b/src/evaluator/special-form.ts
@@ -9,6 +9,8 @@ export type SpecialFormKeywordToType = {
   cond: 'cond';
   lambda: 'lambda';
   let: 'let';
+  'let*': 'let*';
+  letrec: 'letrec';
   quote: 'quote';
 };
 
@@ -52,6 +54,28 @@ export const special_forms: Record<SpecialFormKeywords, Form[]> = {
         json_plus(json_var('bodies'), []),
       ]),
       form: 'let',
+    },
+  ],
+  'let*': [
+    {
+      pattern: jsonRead([
+        'let*',
+        json_star([json_var('ids'), json_var('val_exprs')], []),
+        '.',
+        json_plus(json_var('bodies'), []),
+      ]),
+      form: 'let*',
+    },
+  ],
+  letrec: [
+    {
+      pattern: jsonRead([
+        'letrec',
+        json_star([json_var('ids'), json_var('val_exprs')], []),
+        '.',
+        json_plus(json_var('bodies'), []),
+      ]),
+      form: 'letrec',
     },
   ],
   quote: [

--- a/src/evaluator/types.ts
+++ b/src/evaluator/types.ts
@@ -1,10 +1,9 @@
 import { Result } from '../utils';
 import { SExpr, SListStruct } from '../sexpr';
 import { Environment } from './environment';
+import { EvalData } from './datatypes';
 
-export type Closure = void;
-
-export type EvalValue = SListStruct<Closure>;
+export type EvalValue = SListStruct<EvalData>;
 
 export type EvalResult = Result<EvalValue, void>;
 

--- a/src/pattern/__tests__/pattern.ts
+++ b/src/pattern/__tests__/pattern.ts
@@ -4,7 +4,7 @@ import { json_plus, json_star, json_var, match, PatternLeaf } from '../pattern';
 function expectJsonGoodPatternMatch(program: JsonSExpr<never>, pattern: JsonSExpr<PatternLeaf>) {
   const matches = match(jsonRead(program), jsonRead(pattern));
   expect({ program, pattern, matches }).not.toEqual({ program, pattern, undefined });
-  const json_matches = {};
+  const json_matches = {} as Record<string, JsonSExpr<never>[]>;
   Object.entries(matches!).forEach(
     ([k, v]: [string, SExpr[]]) => (json_matches[k] = v.map(jsonPrint))
   );

--- a/src/pattern/__tests__/pattern.ts
+++ b/src/pattern/__tests__/pattern.ts
@@ -3,7 +3,9 @@ import { json_plus, json_star, json_var, match, PatternLeaf } from '../pattern';
 
 function expectJsonGoodPatternMatch(program: JsonSExpr<never>, pattern: JsonSExpr<PatternLeaf>) {
   const matches = match(jsonRead(program), jsonRead(pattern));
-  expect({ program, pattern, matches }).not.toEqual({ program, pattern, undefined });
+  if (matches === undefined) {
+    expect({ program, pattern, matches }).not.toEqual({ program, pattern, undefined });
+  }
   const json_matches = {} as Record<string, JsonSExpr<never>[]>;
   Object.entries(matches!).forEach(
     ([k, v]: [string, SExpr[]]) => (json_matches[k] = v.map(jsonPrint))
@@ -13,7 +15,9 @@ function expectJsonGoodPatternMatch(program: JsonSExpr<never>, pattern: JsonSExp
 
 function expectJsonBadPatternMatch(program: JsonSExpr<never>, pattern: JsonSExpr<PatternLeaf>) {
   const matches = match(jsonRead(program), jsonRead(pattern));
-  expect({ program, pattern, matches }).toEqual({ program, pattern, undefined });
+  if (matches !== undefined) {
+    expect({ program, pattern, matches }).toEqual({ program, pattern, undefined });
+  }
 }
 
 describe('Basic pattern matching', () => {

--- a/src/printer/__tests__/printer.ts
+++ b/src/printer/__tests__/printer.ts
@@ -1,10 +1,10 @@
-import { satom, sboolean, scons, slist, snil, snumber } from '../../sexpr';
+import { ssymbol, sboolean, scons, slist, snil, snumber } from '../../sexpr';
 import { print } from '../printer';
 
 describe('valid print tests', () => {
-  test('basic atoms', () => {
-    expect(print(satom('abc'))).toMatchInlineSnapshot(`"abc"`);
-    expect(print(satom('abc->def'))).toMatchInlineSnapshot(`"abc->def"`);
+  test('basic symbols', () => {
+    expect(print(ssymbol('abc'))).toMatchInlineSnapshot(`"abc"`);
+    expect(print(ssymbol('abc->def'))).toMatchInlineSnapshot(`"abc->def"`);
   });
 
   test('basic numbers', () => {
@@ -22,16 +22,20 @@ describe('valid print tests', () => {
   });
 
   test('basic list', () => {
-    expect(print(slist([satom('abc')], snil()))).toMatchInlineSnapshot(`"(abc)"`);
-    expect(print(slist([satom('abc'), snumber(123)], snil()))).toMatchInlineSnapshot(`"(abc 123)"`);
+    expect(print(slist([ssymbol('abc')], snil()))).toMatchInlineSnapshot(`"(abc)"`);
+    expect(print(slist([ssymbol('abc'), snumber(123)], snil()))).toMatchInlineSnapshot(
+      `"(abc 123)"`
+    );
     expect(
-      print(slist([satom('abc'), snumber(123), sboolean(true)], snil()))
+      print(slist([ssymbol('abc'), snumber(123), sboolean(true)], snil()))
     ).toMatchInlineSnapshot(`"(abc 123 #t)"`);
   });
 
   test('basic cons', () => {
-    expect(print(scons(satom('abc'), snil()))).toMatchInlineSnapshot(`"(abc)"`);
-    expect(print(scons(satom('a'), satom('b')))).toMatchInlineSnapshot(`"(a . b)"`);
-    expect(print(slist([satom('a'), satom('b')], satom('c')))).toMatchInlineSnapshot(`"(a b . c)"`);
+    expect(print(scons(ssymbol('abc'), snil()))).toMatchInlineSnapshot(`"(abc)"`);
+    expect(print(scons(ssymbol('a'), ssymbol('b')))).toMatchInlineSnapshot(`"(a . b)"`);
+    expect(print(slist([ssymbol('a'), ssymbol('b')], ssymbol('c')))).toMatchInlineSnapshot(
+      `"(a b . c)"`
+    );
   });
 });

--- a/src/printer/__tests__/printer.ts
+++ b/src/printer/__tests__/printer.ts
@@ -10,6 +10,9 @@ describe('valid print tests', () => {
   test('basic numbers', () => {
     expect(print(snumber(123))).toMatchInlineSnapshot(`"123"`);
     expect(print(snumber(123.5))).toMatchInlineSnapshot(`"123.5"`);
+    expect(print(snumber(Infinity))).toMatchInlineSnapshot(`"+inf.0"`);
+    expect(print(snumber(-Infinity))).toMatchInlineSnapshot(`"-inf.0"`);
+    expect(print(snumber(NaN))).toMatchInlineSnapshot(`"+nan.0"`);
   });
 
   test('basic booleans', () => {

--- a/src/printer/__tests__/printer.ts
+++ b/src/printer/__tests__/printer.ts
@@ -1,4 +1,4 @@
-import { ssymbol, sboolean, scons, slist, snil, snumber } from '../../sexpr';
+import { ssymbol, sboolean, scons, slist, snil, snumber, sbox } from '../../sexpr';
 import { print } from '../printer';
 
 describe('valid print tests', () => {
@@ -37,5 +37,11 @@ describe('valid print tests', () => {
     expect(print(slist([ssymbol('a'), ssymbol('b')], ssymbol('c')))).toMatchInlineSnapshot(
       `"(a b . c)"`
     );
+  });
+
+  test('basic boxed', () => {
+    expect(print(sbox(null))).toMatchInlineSnapshot(`"#boxed"`);
+    expect(print(sbox('anything i want'))).toMatchInlineSnapshot(`"#boxed"`);
+    expect(print(sbox(['anything', 'i', 1]))).toMatchInlineSnapshot(`"#boxed"`);
   });
 });

--- a/src/printer/printer.ts
+++ b/src/printer/printer.ts
@@ -1,6 +1,6 @@
-import { STypes, SExpr, val, car, cdr, is_list, is_nil } from '../sexpr';
+import { STypes, SListStruct, val, car, cdr, is_list, is_nil } from '../sexpr';
 
-export function print(e: SExpr): string {
+export function print<T>(e: SListStruct<T>): string {
   switch (e._type) {
     case STypes.Nil:
       return '()';
@@ -30,7 +30,7 @@ export function print(e: SExpr): string {
 
       return ''.concat(...output);
     }
-    default:
-      return '';
+    case STypes.Boxed:
+      return '#boxed';
   }
 }

--- a/src/printer/printer.ts
+++ b/src/printer/printer.ts
@@ -7,7 +7,15 @@ export function print<T>(e: SListStruct<T>): string {
     case STypes.Symbol:
       return val(e);
     case STypes.Number:
-      return val(e).toString();
+      if (Number.isNaN(val(e))) {
+        return '+nan.0';
+      } else if (val(e) === Infinity) {
+        return '+inf.0';
+      } else if (val(e) === -Infinity) {
+        return '-inf.0';
+      } else {
+        return val(e).toString();
+      }
     case STypes.Boolean:
       return val(e) ? '#t' : '#f';
     case STypes.List: {

--- a/src/printer/printer.ts
+++ b/src/printer/printer.ts
@@ -4,7 +4,7 @@ export function print(e: SExpr): string {
   switch (e._type) {
     case STypes.Nil:
       return '()';
-    case STypes.Atom:
+    case STypes.Symbol:
       return val(e);
     case STypes.Number:
       return val(e).toString();

--- a/src/reader/__tests__/reader.ts
+++ b/src/reader/__tests__/reader.ts
@@ -13,7 +13,7 @@ describe('valid read tests', () => {
     expectReadAsJson('{}').toMatchInlineSnapshot(`Array []`);
   });
 
-  test('basic atoms', () => {
+  test('basic symbols', () => {
     expectReadAsJson('abc').toMatchInlineSnapshot(`"abc"`);
     expectReadAsJson('abc->def').toMatchInlineSnapshot(`"abc->def"`);
   });
@@ -198,7 +198,7 @@ describe('invalid read tests', () => {
     `);
   });
 
-  test('bad atoms', () => {
+  test('bad symbols', () => {
     expectFormattedReadErr('.').toMatchInlineSnapshot(`
       "Read error at 1:0 to 1:1: Unexpected dot
         1 | .

--- a/src/reader/__tests__/reader.ts
+++ b/src/reader/__tests__/reader.ts
@@ -81,10 +81,46 @@ describe('valid read tests', () => {
         "a",
       ]
     `);
+    expectReadAsJson('`a').toMatchInlineSnapshot(`
+      Array [
+        "quasiquote",
+        "a",
+      ]
+    `);
+    expectReadAsJson(',a').toMatchInlineSnapshot(`
+      Array [
+        "unquote",
+        "a",
+      ]
+    `);
     expectReadAsJson("'()").toMatchInlineSnapshot(`
       Array [
         "quote",
         Array [],
+      ]
+    `);
+    expectReadAsJson('`(+ ,(+ 1 2) ,(+ 3 4))').toMatchInlineSnapshot(`
+      Array [
+        "quasiquote",
+        Array [
+          "+",
+          Array [
+            "unquote",
+            Array [
+              "+",
+              1,
+              2,
+            ],
+          ],
+          Array [
+            "unquote",
+            Array [
+              "+",
+              3,
+              4,
+            ],
+          ],
+        ],
       ]
     `);
     expectReadAsJson("('abc)").toMatchInlineSnapshot(`

--- a/src/reader/__tests__/reader.ts
+++ b/src/reader/__tests__/reader.ts
@@ -185,6 +185,20 @@ describe('valid read tests', () => {
         "b",
       ]
     `);
+
+    expectReadAsJson('abc ; blah').toMatchInlineSnapshot(`"abc"`);
+
+    expectReadAsJson(`
+      ; blah
+      (a b c)
+      ; blah
+    `).toMatchInlineSnapshot(`
+      Array [
+        "a",
+        "b",
+        "c",
+      ]
+    `);
   });
 
   test('basic s expression comments', () => {
@@ -274,6 +288,22 @@ describe('invalid read tests', () => {
       "
     `);
 
+    expectFormattedReadErr('(a . b]').toMatchInlineSnapshot(`
+      "Read error at 1:0 to 1:7: Mismatched parentheses
+        1 | (a . b]
+          | ^~~~~~~
+
+      "
+    `);
+
+    expectFormattedReadErr('(a . b . c]').toMatchInlineSnapshot(`
+      "Read error at 1:0 to 1:11: Mismatched parentheses
+        1 | (a . b . c]
+          | ^~~~~~~~~~~
+
+      "
+    `);
+
     expectFormattedReadErr('([ abc def )]').toMatchInlineSnapshot(`
       "Read error at 1:1 to 1:12: Mismatched parentheses
         1 | ([ abc def )]
@@ -309,6 +339,16 @@ describe('invalid read tests', () => {
       "Read error at 1:0 to 1:1: Unexpected dot
         1 | .
           | ^
+
+      "
+    `);
+  });
+
+  test('bad tokens', () => {
+    expectFormattedReadErr('#a').toMatchInlineSnapshot(`
+      "Read error at 1:0 to 1:2: Invalid token
+        1 | #a
+          | ^~
 
       "
     `);
@@ -379,6 +419,38 @@ describe('invalid read tests', () => {
       "Read error at 1:3 to 1:10: Unexpected dot, too many data between dots of infix list
         1 | (a . b c . d)
           |    ^~~~~~~
+
+      "
+    `);
+
+    expectFormattedReadErr('(#a . b . c)').toMatchInlineSnapshot(`
+      "Read error at 1:1 to 1:3: Invalid token
+        1 | (#a . b . c)
+          |  ^~
+
+      "
+    `);
+
+    expectFormattedReadErr('(a . #b . c)').toMatchInlineSnapshot(`
+      "Read error at 1:5 to 1:7: Invalid token
+        1 | (a . #b . c)
+          |      ^~
+
+      "
+    `);
+
+    expectFormattedReadErr('(a . b . #c)').toMatchInlineSnapshot(`
+      "Read error at 1:9 to 1:11: Invalid token
+        1 | (a . b . #c)
+          |          ^~
+
+      "
+    `);
+
+    expectFormattedReadErr('(a . b . c . d)').toMatchInlineSnapshot(`
+      "Read error at 1:11 to 1:12: Too many dots in infix list
+        1 | (a . b . c . d)
+          |            ^
 
       "
     `);

--- a/src/reader/reader.ts
+++ b/src/reader/reader.ts
@@ -1,5 +1,5 @@
 import { Result, isGoodResult, ok, err, then } from '../utils';
-import { SExpr, satom, snumber, sboolean, snil, scons, slist } from '../sexpr';
+import { SExpr, ssymbol, snumber, sboolean, snil, scons, slist } from '../sexpr';
 import * as Tok from './token';
 import { Token, tokenize, par_match } from './token';
 import { Location, merge_loc, format_loc, highlight_loc } from '../utils/location';
@@ -19,10 +19,10 @@ ${highlight_loc(err.loc, s, '  ')}
 `;
 }
 
-function token_to_sexpr(tok: Tok.Atom | Tok.Num | Tok.Bool): [SExpr, Location] {
+function token_to_sexpr(tok: Tok.SymbolToken | Tok.Num | Tok.Bool): [SExpr, Location] {
   switch (tok.type) {
-    case 'Atom': {
-      return [satom(tok.contents), tok.loc];
+    case 'Symbol': {
+      return [ssymbol(tok.contents), tok.loc];
     }
     case 'Num': {
       return [snumber(Number.parseFloat(tok.contents)), tok.loc];
@@ -234,7 +234,7 @@ export function readOneDatum(tokens: Token[], i: number = 0): PartialReadResult 
   // Parse quoted
   if (firsttok.type === 'Quote') {
     return then(readOneDatum(tokens, i + 1), ([e, loc, i]) =>
-      ok([slist([satom('quote'), e], snil()), merge_loc(firsttok.loc, loc), i])
+      ok([slist([ssymbol('quote'), e], snil()), merge_loc(firsttok.loc, loc), i])
     );
   }
 

--- a/src/reader/reader.ts
+++ b/src/reader/reader.ts
@@ -207,6 +207,12 @@ function readList(firsttok: Tok.LPar, tokens: Token[], i: number): PartialReadRe
   }
 }
 
+const quote_type = {
+  "'": 'quote',
+  '`': 'quasiquote',
+  ',': 'unquote',
+};
+
 export function readOneDatum(tokens: Token[], i: number = 0): PartialReadResult {
   const firsttok = tokens[i];
 
@@ -232,9 +238,13 @@ export function readOneDatum(tokens: Token[], i: number = 0): PartialReadResult 
   }
 
   // Parse quoted
-  if (firsttok.type === 'Quote') {
+  if (firsttok.type === 'QuoteLike') {
     return then(readOneDatum(tokens, i + 1), ([e, loc, i]) =>
-      ok([slist([ssymbol('quote'), e], snil()), merge_loc(firsttok.loc, loc), i])
+      ok([
+        slist([ssymbol(quote_type[firsttok.contents]), e], snil()),
+        merge_loc(firsttok.loc, loc),
+        i,
+      ])
     );
   }
 

--- a/src/reader/reader.ts
+++ b/src/reader/reader.ts
@@ -44,6 +44,16 @@ function readList(firsttok: Tok.LPar, tokens: Token[], i: number): PartialReadRe
   for (;;) {
     const curtok = tokens[i];
 
+    if (curtok.type === 'SExprComment') {
+      const r = then(readOneDatum(tokens, i + 1), ([e_, loc_, i]) => ok(i));
+      if (isGoodResult(r)) {
+        i = r.v;
+        continue;
+      } else {
+        return r;
+      }
+    }
+
     // Ending at stage 1, no . in this list
     if (curtok.type === 'RPar') {
       i++;
@@ -93,6 +103,16 @@ function readList(firsttok: Tok.LPar, tokens: Token[], i: number): PartialReadRe
   // Stage 2, one . seen
   for (;;) {
     const curtok = tokens[i];
+
+    if (curtok.type === 'SExprComment') {
+      const r = then(readOneDatum(tokens, i + 1), ([e_, loc_, i]) => ok(i));
+      if (isGoodResult(r)) {
+        i = r.v;
+        continue;
+      } else {
+        return r;
+      }
+    }
 
     // Ending at stage 2, one . in this list
     if (curtok.type === 'RPar') {
@@ -163,6 +183,16 @@ function readList(firsttok: Tok.LPar, tokens: Token[], i: number): PartialReadRe
   // Stage 3, two . seen
   for (;;) {
     const curtok = tokens[i];
+
+    if (curtok.type === 'SExprComment') {
+      const r = then(readOneDatum(tokens, i + 1), ([e_, loc_, i]) => ok(i));
+      if (isGoodResult(r)) {
+        i = r.v;
+        continue;
+      } else {
+        return r;
+      }
+    }
 
     // Ending at stage 3, two . in this list
     if (curtok.type === 'RPar') {
@@ -246,6 +276,11 @@ export function readOneDatum(tokens: Token[], i: number = 0): PartialReadResult 
         i,
       ])
     );
+  }
+
+  // Handle S-expression comment
+  if (firsttok.type === 'SExprComment') {
+    return then(readOneDatum(tokens, i + 1), ([e_, loc_, i]) => readOneDatum(tokens, i));
   }
 
   // Everything else is just itself

--- a/src/reader/token.ts
+++ b/src/reader/token.ts
@@ -108,9 +108,21 @@ export function par_match(lpar: LPar, rpar: RPar): boolean {
 }
 
 function substring_to_token(s: string, loc: Location): Token {
-  // Try to interpret as single dot
-  if (s === '.') {
-    return dot('.', loc);
+  // Interpret special cases
+  switch (s) {
+    case '.':
+      return dot('.', loc);
+    case '+inf.0':
+    case '+inf.f':
+      return num('Infinity', loc);
+    case '-inf.0':
+    case '-inf.f':
+      return num('-Infinity', loc);
+    case '+nan.0':
+    case '+nan.f':
+    case '-nan.0':
+    case '-nan.f':
+      return num('NaN', loc);
   }
 
   // Try to interpret as number

--- a/src/reader/token.ts
+++ b/src/reader/token.ts
@@ -260,7 +260,4 @@ export function* tokenize(s: string): Iterable<Token> & Iterator<Token> {
     const end = pos();
     yield substring_to_token(contents, { start, end });
   }
-
-  const curpos = pos();
-  yield eof({ start: curpos, end: curpos });
 }

--- a/src/reader/token.ts
+++ b/src/reader/token.ts
@@ -6,35 +6,43 @@ export interface Base {
   loc: Location;
 }
 
+export type LParContents = '(' | '[' | '{';
 export interface LPar extends Base {
   type: 'LPar';
+  contents: LParContents;
 }
 
-export function lpar(contents: string, loc: Location): LPar {
+export function lpar(contents: LParContents, loc: Location): LPar {
   return { type: 'LPar', contents, loc };
 }
 
+export type RParContents = ')' | ']' | '}';
 export interface RPar extends Base {
   type: 'RPar';
+  contents: RParContents;
 }
 
-export function rpar(contents: string, loc: Location): RPar {
+export function rpar(contents: RParContents, loc: Location): RPar {
   return { type: 'RPar', contents, loc };
 }
 
+export type QuoteLikeContents = "'" | '`' | ',';
 export interface QuoteLike extends Base {
   type: 'QuoteLike';
+  contents: QuoteLikeContents;
 }
 
-export function quote_like(contents: string, loc: Location): QuoteLike {
+export function quote_like(contents: QuoteLikeContents, loc: Location): QuoteLike {
   return { type: 'QuoteLike', contents, loc };
 }
 
+export type DotContents = '.';
 export interface Dot extends Base {
   type: 'Dot';
+  contents: DotContents;
 }
 
-export function dot(contents: string, loc: Location): Dot {
+export function dot(contents: DotContents, loc: Location): Dot {
   return { type: 'Dot', contents, loc };
 }
 
@@ -54,19 +62,23 @@ export function num(contents: string, loc: Location): Num {
   return { type: 'Num', contents, loc };
 }
 
+export type BoolContents = '#t' | '#f';
 export interface Bool extends Base {
   type: 'Bool';
+  contents: BoolContents;
 }
 
-export function bool(contents: string, loc: Location): Bool {
+export function bool(contents: BoolContents, loc: Location): Bool {
   return { type: 'Bool', contents, loc };
 }
 
+export type SExprCommentContents = '#;';
 export interface SExprComment extends Base {
   type: 'SExprComment';
+  contents: SExprCommentContents;
 }
 
-export function sexprcomment(contents: string, loc: Location): SExprComment {
+export function sexprcomment(contents: SExprCommentContents, loc: Location): SExprComment {
   return { type: 'SExprComment', contents, loc };
 }
 
@@ -180,32 +192,30 @@ export function* tokenize(s: string): Iterable<Token> & Iterator<Token> {
 
     const start = pos();
     // Read delimiter character
-    switch (s[i]) {
+    const delimiter_contents = s[i];
+    switch (delimiter_contents) {
       case '(':
       case '[':
       case '{': {
-        const contents = s[i];
         inc();
         const end = pos();
-        yield lpar(contents, { start, end });
+        yield lpar(delimiter_contents, { start, end });
         continue;
       }
       case ')':
       case ']':
       case '}': {
-        const contents = s[i];
         inc();
         const end = pos();
-        yield rpar(contents, { start, end });
+        yield rpar(delimiter_contents, { start, end });
         continue;
       }
       case "'":
       case '`':
       case ',': {
-        const contents = s[i];
         inc();
         const end = pos();
-        yield quote_like(contents, { start, end });
+        yield quote_like(delimiter_contents, { start, end });
         continue;
       }
       case ';': {
@@ -227,22 +237,22 @@ export function* tokenize(s: string): Iterable<Token> & Iterator<Token> {
         // one character dispatches
         inc();
         inc();
-        const contents = s.slice(j, i);
+        const one_char_dispatch_contents = s.slice(j, i);
         const end = pos();
-        switch (contents[1]) {
-          case 't':
-          case 'f': {
-            yield bool(contents, { start, end });
+        switch (one_char_dispatch_contents) {
+          case '#t':
+          case '#f': {
+            yield bool(one_char_dispatch_contents, { start, end });
             continue;
           }
-          case ';': {
-            yield sexprcomment(contents, { start, end });
+          case '#;': {
+            yield sexprcomment(one_char_dispatch_contents, { start, end });
             continue;
           }
         }
 
         // dispatch not supported, output invalid
-        yield invalid(contents, { start, end });
+        yield invalid(one_char_dispatch_contents, { start, end });
         continue;
       }
     }

--- a/src/reader/token.ts
+++ b/src/reader/token.ts
@@ -22,12 +22,12 @@ export function rpar(contents: string, loc: Location): RPar {
   return { type: 'RPar', contents, loc };
 }
 
-export interface Quote extends Base {
-  type: 'Quote';
+export interface QuoteLike extends Base {
+  type: 'QuoteLike';
 }
 
-export function quote(contents: string, loc: Location): Quote {
-  return { type: 'Quote', contents, loc };
+export function quote_like(contents: string, loc: Location): QuoteLike {
+  return { type: 'QuoteLike', contents, loc };
 }
 
 export interface Dot extends Base {
@@ -79,7 +79,7 @@ export function eof(loc: Location): EOF {
   return { type: 'EOF', contents: '', loc };
 }
 
-export type Token = LPar | RPar | Quote | Dot | SymbolToken | Num | Bool | Invalid | EOF;
+export type Token = LPar | RPar | QuoteLike | Dot | SymbolToken | Num | Bool | Invalid | EOF;
 
 export function par_match(lpar: LPar, rpar: RPar): boolean {
   return (
@@ -178,11 +178,13 @@ export function* tokenize(s: string): Iterable<Token> & Iterator<Token> {
         yield rpar(contents, { start, end });
         continue;
       }
-      case "'": {
+      case "'":
+      case '`':
+      case ',': {
         const contents = s[i];
         inc();
         const end = pos();
-        yield quote(contents, { start, end });
+        yield quote_like(contents, { start, end });
         continue;
       }
       case ';': {

--- a/src/reader/token.ts
+++ b/src/reader/token.ts
@@ -38,12 +38,12 @@ export function dot(contents: string, loc: Location): Dot {
   return { type: 'Dot', contents, loc };
 }
 
-export interface Atom extends Base {
-  type: 'Atom';
+export interface SymbolToken extends Base {
+  type: 'Symbol';
 }
 
-export function atom(contents: string, loc: Location): Atom {
-  return { type: 'Atom', contents, loc };
+export function symbol_token(contents: string, loc: Location): SymbolToken {
+  return { type: 'Symbol', contents, loc };
 }
 
 export interface Num extends Base {
@@ -79,7 +79,7 @@ export function eof(loc: Location): EOF {
   return { type: 'EOF', contents: '', loc };
 }
 
-export type Token = LPar | RPar | Quote | Dot | Atom | Num | Bool | Invalid | EOF;
+export type Token = LPar | RPar | Quote | Dot | SymbolToken | Num | Bool | Invalid | EOF;
 
 export function par_match(lpar: LPar, rpar: RPar): boolean {
   return (
@@ -109,8 +109,8 @@ function substring_to_token(s: string, loc: Location): Token {
     return num(s, loc);
   }
 
-  // I guess it's an atom, :P
-  return atom(s, loc);
+  // I guess it's a symbol, :P
+  return symbol_token(s, loc);
 }
 
 const ws_regex = /\s/;

--- a/src/sexpr/__tests__/jsonsexpr.ts
+++ b/src/sexpr/__tests__/jsonsexpr.ts
@@ -1,4 +1,4 @@
-import { satom, snil, scons, slist } from '../sexpr';
+import { ssymbol, snil, scons, slist } from '../sexpr';
 import { jsonPrint } from '../jsonsexpr';
 
 test('correct json representation of complex lists', () => {
@@ -44,14 +44,14 @@ test('correct json representation of complex lists', () => {
       ],
     ]
   `);
-  expect(jsonPrint(scons(satom('a'), satom('b')))).toMatchInlineSnapshot(`
+  expect(jsonPrint(scons(ssymbol('a'), ssymbol('b')))).toMatchInlineSnapshot(`
     Array [
       "a",
       ".",
       "b",
     ]
   `);
-  expect(jsonPrint(scons(satom('a'), scons(satom('b'), satom('c'))))).toMatchInlineSnapshot(`
+  expect(jsonPrint(scons(ssymbol('a'), scons(ssymbol('b'), ssymbol('c'))))).toMatchInlineSnapshot(`
     Array [
       "a",
       "b",

--- a/src/sexpr/__tests__/sexpr.ts
+++ b/src/sexpr/__tests__/sexpr.ts
@@ -1,12 +1,12 @@
 import { SExpr } from '../sexpr';
-import { satom, snumber, sboolean, snil, scons, slist } from '../sexpr';
+import { ssymbol, snumber, sboolean, snil, scons, slist } from '../sexpr';
 import { equals } from '../sexpr';
 import { jsonPrint, jsonRead } from '../jsonsexpr';
 
 describe('test equality', () => {
   const values: (() => SExpr)[] = [
-    () => satom('abc'),
-    () => satom('a.'),
+    () => ssymbol('abc'),
+    () => ssymbol('a.'),
     () => snumber(1),
     () => snumber(999999999999999999999),
     () => sboolean(true),
@@ -188,8 +188,8 @@ describe('test equality', () => {
 });
 
 describe('SExpr -> JsonSExpr -> SExpr identity', () => {
-  const a = satom('a');
-  const b = satom('b');
+  const a = ssymbol('a');
+  const b = ssymbol('b');
   const z = snumber(0);
   const s = snumber(6);
   const t = sboolean(true);

--- a/src/sexpr/__tests__/sexpr.ts
+++ b/src/sexpr/__tests__/sexpr.ts
@@ -20,7 +20,11 @@ describe('test equality', () => {
       const rhs = values[i]();
       const test1 = equals(lhs, rhs);
       const test2 = equals(rhs, lhs);
-      expect({ lhs, rhs, test1, test2 }).toEqual({ lhs, rhs, test1: true, test2: true });
+      if (!test1 || !test2) {
+        expect({ i, lhs, rhs }).toBe({
+          _: 'test failed, see parameters',
+        });
+      }
     }
   });
   test('value inequality', () => {
@@ -30,7 +34,11 @@ describe('test equality', () => {
         const rhs = values[j]();
         const test1 = equals(lhs, rhs);
         const test2 = equals(rhs, lhs);
-        expect({ lhs, rhs, test1, test2 }).toEqual({ lhs, rhs, test1: false, test2: false });
+        if (test1 || test2) {
+          expect({ i, lhs, rhs }).toBe({
+            _: 'test failed, see parameters',
+          });
+        }
       }
     }
   });
@@ -61,7 +69,11 @@ describe('test equality', () => {
             const rhs = one_value_list_structures[i][k](values[vi]());
             const test1 = equals(lhs, rhs);
             const test2 = equals(rhs, lhs);
-            expect({ lhs, rhs, test1, test2 }).toEqual({ lhs, rhs, test1: true, test2: true });
+            if (!test1 || !test2) {
+              expect({ vi, i, j, k, lhs, rhs }).toBe({
+                _: 'test failed, see parameters',
+              });
+            }
           }
         }
       }
@@ -77,7 +89,11 @@ describe('test equality', () => {
               const rhs = one_value_list_structures[ii][jj](values[vi]());
               const test1 = equals(lhs, rhs);
               const test2 = equals(rhs, lhs);
-              expect({ lhs, rhs, test1, test2 }).toEqual({ lhs, rhs, test1: false, test2: false });
+              if (test1 || test2) {
+                expect({ vi, i, j, ii, jj, lhs, rhs }).toBe({
+                  _: 'test failed, see parameters',
+                });
+              }
             }
           }
         }
@@ -94,7 +110,11 @@ describe('test equality', () => {
               const rhs = one_value_list_structures[i][k](values[vii]());
               const test1 = equals(lhs, rhs);
               const test2 = equals(rhs, lhs);
-              expect({ lhs, rhs, test1, test2 }).toEqual({ lhs, rhs, test1: false, test2: false });
+              if (test1 || test2) {
+                expect({ vi, vii, i, j, k, lhs, rhs }).toBe({
+                  _: 'test failed, see parameters',
+                });
+              }
             }
           }
         }
@@ -128,7 +148,11 @@ describe('test equality', () => {
               const rhs = two_value_list_structures[i][k](values[vi](), values[vj]());
               const test1 = equals(lhs, rhs);
               const test2 = equals(rhs, lhs);
-              expect({ lhs, rhs, test1, test2 }).toEqual({ lhs, rhs, test1: true, test2: true });
+              if (!test1 || !test2) {
+                expect({ vi, vj, i, j, k, lhs, rhs }).toBe({
+                  _: 'test failed, see parameters',
+                });
+              }
             }
           }
         }
@@ -146,12 +170,11 @@ describe('test equality', () => {
                 const rhs = two_value_list_structures[ii][jj](values[vi](), values[vj]());
                 const test1 = equals(lhs, rhs);
                 const test2 = equals(rhs, lhs);
-                expect({ lhs, rhs, test1, test2 }).toEqual({
-                  lhs,
-                  rhs,
-                  test1: false,
-                  test2: false,
-                });
+                if (test1 || test2) {
+                  expect({ vi, vj, i, j, ii, jj, lhs, rhs }).toBe({
+                    _: 'test failed, see parameters',
+                  });
+                }
               }
             }
           }
@@ -171,12 +194,11 @@ describe('test equality', () => {
                   const rhs = two_value_list_structures[i][k](values[vii](), values[vjj]());
                   const test1 = equals(lhs, rhs);
                   const test2 = equals(rhs, lhs);
-                  expect({ lhs, rhs, test1, test2 }).toEqual({
-                    lhs,
-                    rhs,
-                    test1: false,
-                    test2: false,
-                  });
+                  if (test1 || test2) {
+                    expect({ vi, vj, vii, vjj, i, j, k, lhs, rhs }).toBe({
+                      _: 'test failed, see parameters',
+                    });
+                  }
                 }
               }
             }
@@ -197,10 +219,10 @@ describe('SExpr -> JsonSExpr -> SExpr identity', () => {
   const n = snil();
 
   test.each([[a], [b], [z], [s], [t], [f], [n]] as SExpr[][])('values', (e: SExpr) => {
-    expect({ e, test: equals(jsonRead(jsonPrint(e)), e) }).toEqual({
-      e,
-      test: true,
-    });
+    const ee = jsonRead(jsonPrint(e));
+    if (!equals(e, ee)) {
+      expect(ee).toBe(e);
+    }
   });
 
   test.each([
@@ -211,9 +233,9 @@ describe('SExpr -> JsonSExpr -> SExpr identity', () => {
     [slist([a, b], slist([z, s], t))],
     [slist([a, slist([b, z, s], t)], f)],
   ] as SExpr[][])('lists', (e: SExpr) => {
-    expect({ e, test: equals(jsonRead(jsonPrint(e)), e) }).toEqual({
-      e,
-      test: true,
-    });
+    const ee = jsonRead(jsonPrint(e));
+    if (!equals(e, ee)) {
+      expect(ee).toBe(e);
+    }
   });
 });

--- a/src/sexpr/jsonsexpr.ts
+++ b/src/sexpr/jsonsexpr.ts
@@ -1,12 +1,12 @@
 import { sbox, SListStruct } from './sexpr';
 import { val, car, cdr } from './sexpr';
-import { satom, snumber, sboolean, snil, slist } from './sexpr';
-import { is_atom, is_number, is_boolean, is_nil, is_list, is_boxed } from './sexpr';
+import { ssymbol, snumber, sboolean, snil, slist } from './sexpr';
+import { is_symbol, is_number, is_boolean, is_nil, is_list, is_boxed } from './sexpr';
 
 export type JsonSExpr<T> = JsonSExpr<T>[] | string | number | boolean | { boxed: T };
 
 export function jsonPrint<T>(e: SListStruct<T>): JsonSExpr<T> {
-  if (is_atom(e) || is_number(e) || is_boolean(e)) {
+  if (is_symbol(e) || is_number(e) || is_boolean(e)) {
     return val(e);
   } else if (is_nil(e)) {
     return [];
@@ -30,7 +30,7 @@ export function jsonPrint<T>(e: SListStruct<T>): JsonSExpr<T> {
 
 export function jsonRead<T>(j: JsonSExpr<T>): SListStruct<T> {
   if (typeof j === 'string') {
-    return satom(j);
+    return ssymbol(j);
   } else if (typeof j === 'number') {
     return snumber(j);
   } else if (typeof j === 'boolean') {

--- a/src/sexpr/sexpr.ts
+++ b/src/sexpr/sexpr.ts
@@ -46,20 +46,17 @@ interface SListPair<T> extends SListBase {
   y: SListStruct<T>;
 }
 
-export interface SBoxed<T> {
+interface SBoxedF<T> {
   _type: STypes.Boxed;
   val: T;
 }
 
+export type SBoxed<T> = T extends never ? never : SBoxedF<T>;
+
 export type SList<T> = SListPair<T>;
 export type SListStruct<T> = SExprBase<T> | SList<T>;
 
-export type SExprBase<T> =
-  | SSymbol
-  | SNumber
-  | SBoolean
-  | SNil
-  | (T extends never ? never : SBoxed<T>);
+export type SExprBase<T> = SSymbol | SNumber | SBoolean | SNil | SBoxed<T>;
 
 export type SExpr = SListStruct<never>;
 
@@ -88,7 +85,8 @@ export function slist<T>(xs: SListStruct<T>[], tail: SListStruct<T>): SListStruc
   return xs.reduceRight((p, x) => scons(x, p), tail);
 }
 
-export const sbox = <T>(val: T): SBoxed<T> => ({ _type: STypes.Boxed, val });
+export const sbox = <T>(val: T): SBoxed<T> =>
+  ({ _type: STypes.Boxed, val } as T extends never ? never : { _type: STypes.Boxed; val: T });
 
 /*************
  * ACCESSORS *
@@ -126,8 +124,7 @@ export const is_nil = <T>(e: SListStruct<T>): e is SNil => e._type === STypes.Ni
 export const is_value = <T>(e: SListStruct<T>): e is SNumber | SBoolean =>
   e._type === STypes.Number || e._type === STypes.Boolean;
 export const is_list = <T>(e: SListStruct<T>): e is SList<T> => e._type === STypes.List;
-export const is_boxed = <T>(e: SListStruct<T>): e is T extends never ? never : SBoxed<T> =>
-  e._type === STypes.Boxed;
+export const is_boxed = <T>(e: SListStruct<T>): e is SBoxed<T> => e._type === STypes.Boxed;
 
 /*************
  * UTILITIES *

--- a/src/sexpr/sexpr.ts
+++ b/src/sexpr/sexpr.ts
@@ -3,7 +3,7 @@
  *********/
 
 export enum STypes {
-  Atom,
+  Symbol,
   Number,
   Boolean,
   Nil,
@@ -11,8 +11,8 @@ export enum STypes {
   Boxed,
 }
 
-export interface SAtom {
-  _type: STypes.Atom;
+export interface SSymbol {
+  _type: STypes.Symbol;
   val: string;
 }
 
@@ -55,7 +55,7 @@ export type SList<T> = SListPair<T>;
 export type SListStruct<T> = SExprBase<T> | SList<T>;
 
 export type SExprBase<T> =
-  | SAtom
+  | SSymbol
   | SNumber
   | SBoolean
   | SNil
@@ -67,7 +67,7 @@ export type SExpr = SListStruct<never>;
  * CONSTRUCTORS *
  ****************/
 
-export const satom = (val: string): SAtom => ({ _type: STypes.Atom, val });
+export const ssymbol = (val: string): SSymbol => ({ _type: STypes.Symbol, val });
 export const snumber = (val: number): SNumber => ({ _type: STypes.Number, val });
 export const sboolean = (val: boolean): SBoolean => ({
   _type: STypes.Boolean,
@@ -94,22 +94,22 @@ export const sbox = <T>(val: T): SBoxed<T> => ({ _type: STypes.Boxed, val });
  * ACCESSORS *
  *************/
 
-export function val(e: SAtom): string;
+export function val(e: SSymbol): string;
 export function val(e: SNumber): number;
 export function val(e: SBoolean): boolean;
-export function val(e: SAtom | SNumber): string | number;
-export function val(e: SAtom | SBoolean): string | boolean;
+export function val(e: SSymbol | SNumber): string | number;
+export function val(e: SSymbol | SBoolean): string | boolean;
 export function val(e: SNumber | SBoolean): number | boolean;
-export function val(e: SAtom | SNumber | SBoolean): string | number | boolean;
+export function val(e: SSymbol | SNumber | SBoolean): string | number | boolean;
 export function val<T>(e: SBoxed<T>): T;
-export function val<T>(e: SAtom | SBoxed<T>): string | T;
+export function val<T>(e: SSymbol | SBoxed<T>): string | T;
 export function val<T>(e: SNumber | SBoxed<T>): number | T;
 export function val<T>(e: SBoolean | SBoxed<T>): boolean | T;
-export function val<T>(e: SAtom | SNumber | SBoxed<T>): string | number | T;
-export function val<T>(e: SAtom | SBoolean | SBoxed<T>): string | boolean | T;
+export function val<T>(e: SSymbol | SNumber | SBoxed<T>): string | number | T;
+export function val<T>(e: SSymbol | SBoolean | SBoxed<T>): string | boolean | T;
 export function val<T>(e: SNumber | SBoolean | SBoxed<T>): number | boolean | T;
-export function val<T>(e: SAtom | SNumber | SBoolean | SBoxed<T>): string | number | boolean | T;
-export function val<T>(e: SAtom | SNumber | SBoolean | SBoxed<T>): string | number | boolean | T {
+export function val<T>(e: SSymbol | SNumber | SBoolean | SBoxed<T>): string | number | boolean | T;
+export function val<T>(e: SSymbol | SNumber | SBoolean | SBoxed<T>): string | number | boolean | T {
   return e.val;
 }
 export const car = <T>(p: SList<T>): SListStruct<T> => p.x;
@@ -119,7 +119,7 @@ export const cdr = <T>(p: SList<T>): SListStruct<T> => p.y;
  * PREDICATES *
  **************/
 
-export const is_atom = <T>(e: SListStruct<T>): e is SAtom => e._type === STypes.Atom;
+export const is_symbol = <T>(e: SListStruct<T>): e is SSymbol => e._type === STypes.Symbol;
 export const is_number = <T>(e: SListStruct<T>): e is SNumber => e._type === STypes.Number;
 export const is_boolean = <T>(e: SListStruct<T>): e is SBoolean => e._type === STypes.Boolean;
 export const is_nil = <T>(e: SListStruct<T>): e is SNil => e._type === STypes.Nil;
@@ -138,8 +138,8 @@ export function equals<E1 extends SListStruct<unknown>>(e1: E1, e2: SListStruct<
 export function equals(e1: SListStruct<unknown>, e2: SListStruct<unknown>): boolean {
   for (;;) {
     if (
-      (e1._type === STypes.Atom || e1._type === STypes.Number || e1._type === STypes.Boolean) &&
-      (e2._type === STypes.Atom || e2._type === STypes.Number || e2._type === STypes.Boolean)
+      (e1._type === STypes.Symbol || e1._type === STypes.Number || e1._type === STypes.Boolean) &&
+      (e2._type === STypes.Symbol || e2._type === STypes.Number || e2._type === STypes.Boolean)
     ) {
       return val(e1) === val(e2);
     } else if (e1._type === STypes.Nil && e2._type === STypes.Nil) {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,13 +1,55 @@
-export function formatTable(t: string[][]): string {
+function interleave<T>(xs: T[], sep: T): T[] {
+  const result: T[] = [];
+  for (let i = 0; i < xs.length - 1; i++) {
+    result.push(xs[i]);
+    result.push(sep);
+  }
+  result.push(xs[xs.length - 1]);
+  return result;
+}
+
+export function formatTable(
+  t: string[][],
+  options: { headers?: string[]; sep?: string; prefix?: string } = {}
+): string {
   if (t.length === 0) {
     return '';
   }
 
+  let { headers } = options;
+  const { sep, prefix } = options;
+
+  if (sep !== undefined) {
+    if (headers !== undefined) {
+      headers = interleave(headers, sep);
+    }
+    t = t.map((row) => interleave(row, sep));
+  }
+
   const widths = t[0].map((_, i) => {
-    return Math.max(...t.map((r) => r[i].length));
+    if (headers === undefined) {
+      return Math.max(...t.map((r) => r[i].length));
+    } else {
+      return Math.max(headers[i].length, ...t.map((r) => r[i].length));
+    }
   });
 
   const strs: string[] = [];
+
+  if (prefix !== undefined) {
+    strs.push(prefix);
+  }
+
+  if (headers !== undefined) {
+    for (let c = 0; c < headers.length - 1; c++) {
+      strs.push(headers[c] + ' '.repeat(widths[c] - headers[c].length));
+    }
+    strs.push(headers[headers.length - 1]);
+    strs.push('\n');
+    strs.push('-'.repeat(widths.reduce((x, y) => x + y, 0)));
+    strs.push('\n');
+  }
+
   t.forEach((row: string[]) => {
     // pad everything except last column in table
     // for now assume everything is left aligned

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './result';
 export * from './location';
 export * from './formatters';
+export * from './types';

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -48,6 +48,14 @@ export function then<T, U, Err>(r: Result<T, Err>, cb: (v: T) => Result<U, Err>)
   }
 }
 
+export function cases<T, Err, U>(r: Result<T, Err>, good: (v: T) => U, bad: (err: Err) => U): U {
+  if (isGoodResult(r)) {
+    return good(r.v);
+  } else {
+    return bad(r.err);
+  }
+}
+
 export type Result<T, Err> = GoodResult<T> | BadResult<Err>;
 
 export function ok<T>(v: T): GoodResult<T> {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,3 @@
+export function hasKey<O>(obj: O, key: keyof any): key is keyof O {
+  return key in obj;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "resolveJsonModule": true,
     "incremental": true
   },


### PR DESCRIPTION
Reader upgrade

* Implement quasiquote and unquote in reader
* Implement parsing S-expression comments

Special forms

* Implement lambda expressions
* Implement cond special form
* Implement let* and letrec
* Implement begin expressions

Refactors

* Rename atom to symbol
* Change primitive functions to a special SExpr leaf node

Printer upgrade

* Make printer work on all SListStruct<T>, without trying to print boxed values

Stdlib

* Add a lot of (untested) primitives
- [ ] TODO: Test those primitives
